### PR TITLE
최종 결과 차트 컴포넌트

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
-    "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-tooltip": "^1.1.3",
     "@sentry/nextjs": "8",
     "@tanstack/react-query": "^5.56.2",
     "axios": "^1.7.7",

--- a/src/components/FinalResultChart/Bar.tsx
+++ b/src/components/FinalResultChart/Bar.tsx
@@ -10,21 +10,13 @@ export interface BarProps {
   votes1: number;
   candidate2: string;
   votes2: number;
-  nonParticipants: number;
 }
 
-const Bar = ({
-  votes1,
-  candidate1,
-  votes2,
-  candidate2,
-  nonParticipants,
-}: BarProps) => {
+const Bar = ({ votes1, candidate1, votes2, candidate2 }: BarProps) => {
   const totalVotes = votes1 + votes2;
 
   const percentageCandidate1 = (votes1 / totalVotes) * 100;
   const percentageCandidate2 = (votes2 / totalVotes) * 100;
-  const percentageNonParticipants = (nonParticipants / totalVotes) * 100;
 
   return (
     <div className="w-full flex items-center justify-center gap-6">
@@ -41,20 +33,6 @@ const Bar = ({
             </TooltipTrigger>
             <TooltipContent>
               <p>{percentageCandidate1.toFixed(1)}%</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger
-              className="bg-tertiary flex items-center justify-center" // 미참여자 색상 변경
-              style={{ width: `${percentageNonParticipants}%` }}
-            >
-              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${nonParticipants}`}</span>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{percentageNonParticipants.toFixed(1)}%</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/src/components/FinalResultChart/Bar.tsx
+++ b/src/components/FinalResultChart/Bar.tsx
@@ -5,7 +5,7 @@ import {
   TooltipTrigger,
 } from '@/components/Tooltip';
 
-interface BarProps {
+export interface BarProps {
   candidate1: string;
   votes1: number;
   candidate2: string;

--- a/src/components/FinalResultChart/Bar.tsx
+++ b/src/components/FinalResultChart/Bar.tsx
@@ -26,7 +26,7 @@ const Bar = ({ votes1, candidate1, votes2, candidate2 }: BarProps) => {
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger
-              className="bg-primary rounded-l-full flex items-center justify-center"
+              className={`bg-primary ${votes2 === 0 && 'rounded-r-full'} rounded-l-full flex items-center justify-center`}
               style={{ width: `${percentageCandidate1}%` }}
             >
               <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${votes1}`}</span>

--- a/src/components/FinalResultChart/Bar.tsx
+++ b/src/components/FinalResultChart/Bar.tsx
@@ -4,12 +4,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/Tooltip';
+import clsx from 'clsx';
 
-export interface BarProps {
-  candidate1: string;
-  votes1: number;
-  candidate2: string;
-  votes2: number;
+interface BarItemProps {
+  className: string;
+  isLeft: boolean;
+  percentage: number;
+  votes: number;
 }
 
 const Bar = ({ votes1, candidate1, votes2, candidate2 }: BarProps) => {
@@ -22,39 +23,62 @@ const Bar = ({ votes1, candidate1, votes2, candidate2 }: BarProps) => {
     <div className="w-full flex items-center justify-center gap-6">
       <span className="min-w-[20%] text-right">{candidate1}</span>
 
-      <div className="flex h-8 min-w-[50%]">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger
-              className={`bg-primary ${votes2 === 0 && 'rounded-r-full'} rounded-l-full flex items-center justify-center`}
-              style={{ width: `${percentageCandidate1}%` }}
-            >
-              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${votes1}`}</span>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{percentageCandidate1.toFixed(1)}%</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+      {totalVotes === 0 ? (
+        <div className="min-w-[50%] p-1 bg-container-100 rounded-full flex items-center justify-center">
+          <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">
+            0
+          </span>
+        </div>
+      ) : (
+        <div className="flex h-8 min-w-[50%]">
+          <BarItem
+            className={`bg-primary ${votes2 === 0 && 'rounded-r-full'}`}
+            isLeft={true}
+            percentage={percentageCandidate1}
+            votes={votes1}
+          />
 
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger
-              className={`bg-secondary ${votes1 === 0 && 'rounded-l-full'} rounded-r-full flex items-center justify-center`}
-              style={{ width: `${percentageCandidate2}%` }}
-            >
-              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${votes2}`}</span>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{percentageCandidate2.toFixed(1)}%</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
+          <BarItem
+            className={`bg-secondary ${votes1 === 0 && 'rounded-l-full'} `}
+            isLeft={false}
+            percentage={percentageCandidate2}
+            votes={votes2}
+          />
+        </div>
+      )}
 
       <span className="min-w-[20%]">{candidate2}</span>
     </div>
   );
 };
+
+const BarItem = ({ className, isLeft, percentage, votes }: BarItemProps) => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger
+        className={clsx(
+          className,
+          'flex items-center justify-center',
+          isLeft ? 'rounded-l-full' : 'rounded-r-full'
+        )}
+        style={{ width: `${percentage}%` }}
+      >
+        <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">
+          {votes}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{`${percentage.toFixed(1)}%`}</p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
+export interface BarProps {
+  candidate1: string;
+  votes1: number;
+  candidate2: string;
+  votes2: number;
+}
 
 export default Bar;

--- a/src/components/FinalResultChart/Bar.tsx
+++ b/src/components/FinalResultChart/Bar.tsx
@@ -6,11 +6,11 @@ import {
 } from '@/components/Tooltip';
 import clsx from 'clsx';
 
-interface BarItemProps {
-  className: string;
-  isLeft: boolean;
-  percentage: number;
-  votes: number;
+export interface BarProps {
+  candidate1: string;
+  votes1: number;
+  candidate2: string;
+  votes2: number;
 }
 
 const Bar = ({ votes1, candidate1, votes2, candidate2 }: BarProps) => {
@@ -52,6 +52,13 @@ const Bar = ({ votes1, candidate1, votes2, candidate2 }: BarProps) => {
   );
 };
 
+interface BarItemProps {
+  className: string;
+  isLeft: boolean;
+  percentage: number;
+  votes: number;
+}
+
 const BarItem = ({ className, isLeft, percentage, votes }: BarItemProps) => (
   <TooltipProvider>
     <Tooltip>
@@ -73,12 +80,5 @@ const BarItem = ({ className, isLeft, percentage, votes }: BarItemProps) => (
     </Tooltip>
   </TooltipProvider>
 );
-
-export interface BarProps {
-  candidate1: string;
-  votes1: number;
-  candidate2: string;
-  votes2: number;
-}
 
 export default Bar;

--- a/src/components/FinalResultChart/Bar.tsx
+++ b/src/components/FinalResultChart/Bar.tsx
@@ -1,0 +1,82 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/Tooltip';
+
+interface BarProps {
+  candidate1: string;
+  votes1: number;
+  candidate2: string;
+  votes2: number;
+  nonParticipants: number;
+}
+
+const Bar = ({
+  votes1,
+  candidate1,
+  votes2,
+  candidate2,
+  nonParticipants,
+}: BarProps) => {
+  const totalVotes = votes1 + votes2;
+
+  const percentageCandidate1 = (votes1 / totalVotes) * 100;
+  const percentageCandidate2 = (votes2 / totalVotes) * 100;
+  const percentageNonParticipants = (nonParticipants / totalVotes) * 100;
+
+  return (
+    <div className="w-full flex items-center justify-center gap-6">
+      <span>{candidate1}</span>
+
+      <div className="flex h-8 min-w-[50%]">
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              className="bg-primary rounded-l-full flex items-center justify-center"
+              style={{ width: `${percentageCandidate1}%` }}
+            >
+              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${votes1}`}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{percentageCandidate1.toFixed(1)}%</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              className="bg-tertiary flex items-center justify-center" // 미참여자 색상 변경
+              style={{ width: `${percentageNonParticipants}%` }}
+            >
+              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${nonParticipants}`}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{percentageNonParticipants.toFixed(1)}%</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              className="bg-secondary rounded-r-full flex items-center justify-center"
+              style={{ width: `${percentageCandidate2}%` }}
+            >
+              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${votes2}`}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{percentageCandidate2.toFixed(1)}%</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+
+      <span>{candidate2}</span>
+    </div>
+  );
+};
+
+export default Bar;

--- a/src/components/FinalResultChart/Bar.tsx
+++ b/src/components/FinalResultChart/Bar.tsx
@@ -20,7 +20,7 @@ const Bar = ({ votes1, candidate1, votes2, candidate2 }: BarProps) => {
 
   return (
     <div className="w-full flex items-center justify-center gap-6">
-      <span>{candidate1}</span>
+      <span className="min-w-[20%] text-right">{candidate1}</span>
 
       <div className="flex h-8 min-w-[50%]">
         <TooltipProvider>
@@ -40,7 +40,7 @@ const Bar = ({ votes1, candidate1, votes2, candidate2 }: BarProps) => {
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger
-              className="bg-secondary rounded-r-full flex items-center justify-center"
+              className={`bg-secondary ${votes1 === 0 && 'rounded-l-full'} rounded-r-full flex items-center justify-center`}
               style={{ width: `${percentageCandidate2}%` }}
             >
               <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${votes2}`}</span>
@@ -52,7 +52,7 @@ const Bar = ({ votes1, candidate1, votes2, candidate2 }: BarProps) => {
         </TooltipProvider>
       </div>
 
-      <span>{candidate2}</span>
+      <span className="min-w-[20%]">{candidate2}</span>
     </div>
   );
 };

--- a/src/components/FinalResultChart/Bar.tsx
+++ b/src/components/FinalResultChart/Bar.tsx
@@ -24,13 +24,13 @@ const Bar = ({ votes1, candidate1, votes2, candidate2 }: BarProps) => {
       <span className="min-w-[20%] text-right">{candidate1}</span>
 
       {totalVotes === 0 ? (
-        <div className="min-w-[50%] p-1 bg-container-100 rounded-full flex items-center justify-center">
-          <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">
+        <div className="min-w-[50%] h-5 bg-container-100 rounded-full flex items-center justify-center">
+          <span className="font-bold text-sm bg-clip-text text-transparent bg-gradient-purple text-center w-full">
             0
           </span>
         </div>
       ) : (
-        <div className="flex h-8 min-w-[50%]">
+        <div className="flex h-8 min-w-[50%] h-5">
           <BarItem
             className={`bg-primary ${votes2 === 0 && 'rounded-r-full'}`}
             isLeft={true}
@@ -70,7 +70,7 @@ const BarItem = ({ className, isLeft, percentage, votes }: BarItemProps) => (
         )}
         style={{ width: `${percentage}%` }}
       >
-        <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">
+        <span className="font-bold text-sm bg-clip-text text-transparent bg-gradient-purple text-center w-full">
           {votes}
         </span>
       </TooltipTrigger>

--- a/src/components/FinalResultChart/FinalResultChart.test.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import FinalResultChart from './FinalResultChart';
+
+describe('FinalResultChart 컴포넌트 테스트', () => {
+  it('1) 투표 데이터의 각 후보의 이름이 출력 된다.', () => {
+    const DUMMY = [
+      {
+        candidate1: '강아지',
+        votes1: 2,
+        candidate2: '고양이',
+        votes2: 7,
+      },
+      {
+        candidate1: '강하띠',
+        votes1: 6,
+        candidate2: '코앵히',
+        votes2: 4,
+      },
+      {
+        candidate1: '사과',
+        votes1: 0,
+        candidate2: '바나나',
+        votes2: 9,
+      },
+    ];
+    render(<FinalResultChart data={DUMMY}></FinalResultChart>);
+
+    const texts = ['강아지', '고양이', '강하띠', '코앵히', '사과', '바나나'];
+    texts.forEach((text) => {
+      expect(screen.getByText(text)).toBeInTheDocument();
+    });
+  });
+
+  it('2) 투표 데이터를 넣으면 각 수치가 Bar에 적힌다.', () => {
+    const DUMMY = [
+      { candidate1: '강아지', votes1: 2, candidate2: '고양이', votes2: 7 },
+    ];
+    render(<FinalResultChart data={DUMMY}></FinalResultChart>);
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('3) 한 후보의 투표 수가 0이면 출력되지 않는다.', () => {
+    const DUMMY = [
+      { candidate1: '강아지', votes1: 0, candidate2: '고양이', votes2: 9 },
+    ];
+    render(<FinalResultChart data={DUMMY}></FinalResultChart>);
+
+    const bar = screen.getByText('0').parentElement;
+
+    if (bar) {
+      expect(getComputedStyle(bar).width).toBe('0%');
+    }
+
+    expect(screen.getByText('9')).toBeInTheDocument();
+  });
+
+  it('4) 두 후보의 투표 수가 0이면 0을 출력한다.', () => {
+    const DUMMY = [
+      { candidate1: '강아지', votes1: 0, candidate2: '고양이', votes2: 0 },
+    ];
+    render(<FinalResultChart data={DUMMY}></FinalResultChart>);
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});

--- a/src/components/FinalResultChart/FinalResultChart.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.tsx
@@ -9,7 +9,7 @@ const FinalResultChart = ({ data }: FinalResultChartProps) => {
   return (
     <section className="bg-container-600 h-full w-full flex flex-col justify-center items-center rounded-lg gap-8 p-8">
       <h1 className="text-lg font-semibold">최종 결과</h1>
-      <section className="w-full h-4/5 overflow-y-auto gap-2 flex flex-col items-center">
+      <section className="w-full overflow-y-auto gap-2 flex flex-col items-center">
         {data.map((result, index) => (
           <Bar
             key={index}

--- a/src/components/FinalResultChart/FinalResultChart.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@/components/Button';
 import Bar, { BarProps } from './Bar';
 
 interface FinalResultChartProps {
@@ -6,14 +7,24 @@ interface FinalResultChartProps {
 
 const FinalResultChart = ({ data }: FinalResultChartProps) => {
   return (
-    <div className="bg-container-600 flex flex-col gap-3">
-      {data.map((result, index) => (
-        <Bar
-          key={index}
-          {...result}
-        ></Bar>
-      ))}
-    </div>
+    <section className="bg-container-600 flex flex-col justify-center items-center rounded-lg gap-8 p-4">
+      <h1 className="text-xl font-semibold">최종 결과</h1>
+      <section className="w-full gap-3 flex flex-col justify-center items-center">
+        {data.map((result, index) => (
+          <Bar
+            key={index}
+            {...result}
+          ></Bar>
+        ))}
+      </section>
+      <Button
+        shape="square"
+        size={'xl'}
+        className="font-semibold"
+      >
+        결과 공유하기
+      </Button>
+    </section>
   );
 };
 

--- a/src/components/FinalResultChart/FinalResultChart.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/Button';
 import Bar, { BarProps } from './Bar';
-
+import { Download } from 'lucide-react';
 interface FinalResultChartProps {
   data: BarProps[];
 }
@@ -18,10 +18,10 @@ const FinalResultChart = ({ data }: FinalResultChartProps) => {
         ))}
       </section>
       <Button
-        shape="square"
-        size={'xl'}
         className="font-semibold"
+        variant={'secondary'}
       >
+        <Download />
         결과 공유하기
       </Button>
     </section>

--- a/src/components/FinalResultChart/FinalResultChart.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.tsx
@@ -1,22 +1,18 @@
-import Bar from './Bar';
+import Bar, { BarProps } from './Bar';
 
-const FinalResultChart = () => {
+interface FinalResultChartProps {
+  data: BarProps[];
+}
+
+const FinalResultChart = ({ data }: FinalResultChartProps) => {
   return (
-    <div className="bg-container-600">
-      <Bar
-        candidate1="강아지"
-        votes1={2}
-        candidate2="고양이"
-        votes2={7}
-        nonParticipants={1}
-      ></Bar>
-      <Bar
-        candidate1="강하띠"
-        votes1={4}
-        candidate2="코앵이"
-        votes2={6}
-        nonParticipants={0}
-      ></Bar>
+    <div className="bg-container-600 flex flex-col gap-3">
+      {data.map((result, index) => (
+        <Bar
+          key={index}
+          {...result}
+        ></Bar>
+      ))}
     </div>
   );
 };

--- a/src/components/FinalResultChart/FinalResultChart.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.tsx
@@ -7,9 +7,9 @@ interface FinalResultChartProps {
 
 const FinalResultChart = ({ data }: FinalResultChartProps) => {
   return (
-    <section className="bg-container-600 h-4/5 w-full flex flex-col justify-center items-center rounded-lg gap-8 p-4">
-      <h1 className="text-xl font-semibold">최종 결과</h1>
-      <section className="w-full h-3/5 overflow-y-auto gap-3 flex flex-col items-center">
+    <section className="bg-container-600 h-full w-full flex flex-col justify-center items-center rounded-lg gap-8 p-8">
+      <h1 className="text-lg font-semibold">최종 결과</h1>
+      <section className="w-full h-4/5 overflow-y-auto gap-2 flex flex-col items-center">
         {data.map((result, index) => (
           <Bar
             key={index}
@@ -18,7 +18,7 @@ const FinalResultChart = ({ data }: FinalResultChartProps) => {
         ))}
       </section>
       <Button
-        className="font-semibold"
+        className="font-medium"
         variant={'secondary'}
       >
         <Download />

--- a/src/components/FinalResultChart/FinalResultChart.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.tsx
@@ -1,0 +1,52 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/Tooltip';
+
+interface FinalResultChartProps {
+  votes1: number;
+  votes2: number;
+}
+
+const FinalResultChart = ({ votes1, votes2 }: FinalResultChartProps) => {
+  const totalVotes = votes1 + votes2;
+
+  const percentageCandidate1 = (votes1 / totalVotes) * 100;
+  const percentageCandidate2 = (votes2 / totalVotes) * 100;
+  return (
+    <div className="w-full max-w-xs mx-auto">
+      <div className="flex h-8">
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              className="bg-primary rounded-l-full flex items-center justify-center"
+              style={{ width: `${percentageCandidate1}%` }}
+            >
+              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${votes1}`}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{percentageCandidate1.toFixed(1)}%</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              className="bg-secondary rounded-r-full flex items-center justify-center"
+              style={{ width: `${percentageCandidate2}%` }}
+            >
+              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${votes2}`}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{percentageCandidate2.toFixed(1)}%</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    </div>
+  );
+};
+
+export default FinalResultChart;

--- a/src/components/FinalResultChart/FinalResultChart.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.tsx
@@ -1,72 +1,22 @@
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/Tooltip';
+import Bar from './Bar';
 
-interface FinalResultChartProps {
-  votes1: number;
-  votes2: number;
-  nonParticipants: number;
-}
-
-const FinalResultChart = ({
-  votes1,
-  votes2,
-  nonParticipants,
-}: FinalResultChartProps) => {
-  const totalVotes = votes1 + votes2;
-
-  const percentageCandidate1 = (votes1 / totalVotes) * 100;
-  const percentageCandidate2 = (votes2 / totalVotes) * 100;
-  const percentageNonParticipants = (nonParticipants / totalVotes) * 100;
-
+const FinalResultChart = () => {
   return (
-    <div className="w-full max-w-xs mx-auto">
-      <div className="flex h-8">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger
-              className="bg-primary rounded-l-full flex items-center justify-center"
-              style={{ width: `${percentageCandidate1}%` }}
-            >
-              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${votes1}`}</span>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{percentageCandidate1.toFixed(1)}%</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger
-              className="bg-tertiary flex items-center justify-center" // 미참여자 색상 변경
-              style={{ width: `${percentageNonParticipants}%` }}
-            >
-              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${nonParticipants}`}</span>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{percentageNonParticipants.toFixed(1)}%</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger
-              className="bg-secondary rounded-r-full flex items-center justify-center"
-              style={{ width: `${percentageCandidate2}%` }}
-            >
-              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${votes2}`}</span>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{percentageCandidate2.toFixed(1)}%</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
+    <div className="bg-container-600">
+      <Bar
+        candidate1="강아지"
+        votes1={2}
+        candidate2="고양이"
+        votes2={7}
+        nonParticipants={1}
+      ></Bar>
+      <Bar
+        candidate1="강하띠"
+        votes1={4}
+        candidate2="코앵이"
+        votes2={6}
+        nonParticipants={0}
+      ></Bar>
     </div>
   );
 };

--- a/src/components/FinalResultChart/FinalResultChart.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.tsx
@@ -7,7 +7,7 @@ interface FinalResultChartProps {
 
 const FinalResultChart = ({ data }: FinalResultChartProps) => {
   return (
-    <section className="bg-container-600 h-4/6 flex flex-col justify-center items-center rounded-lg gap-8 p-4">
+    <section className="bg-container-600 h-4/5 w-full flex flex-col justify-center items-center rounded-lg gap-8 p-4">
       <h1 className="text-xl font-semibold">최종 결과</h1>
       <section className="w-full h-3/5 overflow-y-auto gap-3 flex flex-col items-center">
         {data.map((result, index) => (

--- a/src/components/FinalResultChart/FinalResultChart.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.tsx
@@ -7,9 +7,9 @@ interface FinalResultChartProps {
 
 const FinalResultChart = ({ data }: FinalResultChartProps) => {
   return (
-    <section className="bg-container-600 flex flex-col justify-center items-center rounded-lg gap-8 p-4">
+    <section className="bg-container-600 h-4/6 flex flex-col justify-center items-center rounded-lg gap-8 p-4">
       <h1 className="text-xl font-semibold">최종 결과</h1>
-      <section className="w-full gap-3 flex flex-col justify-center items-center">
+      <section className="w-full h-3/5 overflow-y-auto gap-3 flex flex-col items-center">
         {data.map((result, index) => (
           <Bar
             key={index}

--- a/src/components/FinalResultChart/FinalResultChart.tsx
+++ b/src/components/FinalResultChart/FinalResultChart.tsx
@@ -8,13 +8,20 @@ import {
 interface FinalResultChartProps {
   votes1: number;
   votes2: number;
+  nonParticipants: number;
 }
 
-const FinalResultChart = ({ votes1, votes2 }: FinalResultChartProps) => {
+const FinalResultChart = ({
+  votes1,
+  votes2,
+  nonParticipants,
+}: FinalResultChartProps) => {
   const totalVotes = votes1 + votes2;
 
   const percentageCandidate1 = (votes1 / totalVotes) * 100;
   const percentageCandidate2 = (votes2 / totalVotes) * 100;
+  const percentageNonParticipants = (nonParticipants / totalVotes) * 100;
+
   return (
     <div className="w-full max-w-xs mx-auto">
       <div className="flex h-8">
@@ -31,6 +38,21 @@ const FinalResultChart = ({ votes1, votes2 }: FinalResultChartProps) => {
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
+
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              className="bg-tertiary flex items-center justify-center" // 미참여자 색상 변경
+              style={{ width: `${percentageNonParticipants}%` }}
+            >
+              <span className="font-bold bg-clip-text text-transparent bg-gradient-purple text-center w-full">{`${nonParticipants}`}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{percentageNonParticipants.toFixed(1)}%</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger

--- a/src/components/FinalResultChart/index.ts
+++ b/src/components/FinalResultChart/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FinalResultChart';

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
+import { cn } from '@/lib/utils';
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md bg-container-950 px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,0 +1,6 @@
+export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from './Tooltip';

--- a/yarn.lock
+++ b/yarn.lock
@@ -502,6 +502,33 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.8.tgz#aa43561be075815879305965020f492cdb43da12"
+  integrity sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==
+  dependencies:
+    "@floating-ui/utils" "^0.2.8"
+
+"@floating-ui/dom@^1.0.0":
+  version "1.6.12"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.12.tgz#6333dcb5a8ead3b2bf82f33d6bc410e95f54e556"
+  integrity sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.8"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz#a1349bbf6a0e5cb5ded55d023766f20a4d439a31"
+  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
+"@floating-ui/utils@^0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
+  integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
+
 "@hookform/resolvers@^3.9.0":
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.9.0.tgz#cf540ac21c6c0cd24a40cf53d8e6d64391fb753d"
@@ -983,15 +1010,55 @@
     "@opentelemetry/instrumentation" "^0.49 || ^0.50 || ^0.51 || ^0.52.0"
     "@opentelemetry/sdk-trace-base" "^1.22"
 
+"@radix-ui/primitive@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.0.tgz#42ef83b3b56dccad5d703ae8c42919a68798bbe2"
+  integrity sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==
+
+"@radix-ui/react-arrow@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz#744f388182d360b86285217e43b6c63633f39e7a"
+  integrity sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.0"
+
 "@radix-ui/react-compose-refs@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz#656432461fc8283d7b591dcf0d79152fae9ecc74"
   integrity sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==
 
+"@radix-ui/react-context@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.0.tgz#6df8d983546cfd1999c8512f3a8ad85a6e7fcee8"
+  integrity sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==
+
+"@radix-ui/react-context@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.1.tgz#82074aa83a472353bb22e86f11bcbd1c61c4c71a"
+  integrity sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==
+
+"@radix-ui/react-dismissable-layer@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.1.tgz#cbdcb739c5403382bdde5f9243042ba643883396"
+  integrity sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-escape-keydown" "1.1.0"
+
 "@radix-ui/react-icons@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-icons/-/react-icons-1.3.0.tgz#c61af8f323d87682c5ca76b856d60c2312dbcb69"
   integrity sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==
+
+"@radix-ui/react-id@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.0.tgz#de47339656594ad722eb87f94a6b25f9cffae0ed"
+  integrity sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.0"
 
 "@radix-ui/react-label@^2.1.0":
   version "2.1.0"
@@ -1000,6 +1067,38 @@
   dependencies:
     "@radix-ui/react-primitive" "2.0.0"
 
+"@radix-ui/react-popper@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.0.tgz#a3e500193d144fe2d8f5d5e60e393d64111f2a7a"
+  integrity sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+    "@radix-ui/react-use-rect" "1.1.0"
+    "@radix-ui/react-use-size" "1.1.0"
+    "@radix-ui/rect" "1.1.0"
+
+"@radix-ui/react-portal@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.2.tgz#51eb46dae7505074b306ebcb985bf65cc547d74e"
+  integrity sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-presence@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.1.tgz#98aba423dba5e0c687a782c0669dcd99de17f9b1"
+  integrity sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
 "@radix-ui/react-primitive@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz#fe05715faa9203a223ccc0be15dc44b9f9822884"
@@ -1007,12 +1106,80 @@
   dependencies:
     "@radix-ui/react-slot" "1.1.0"
 
-"@radix-ui/react-slot@1.1.0":
+"@radix-ui/react-slot@1.1.0", "@radix-ui/react-slot@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.0.tgz#7c5e48c36ef5496d97b08f1357bb26ed7c714b84"
   integrity sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
+
+"@radix-ui/react-tooltip@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.1.3.tgz#4250b14723f2d8477e7a3d0526c169f91d1f2f74"
+  integrity sha512-Z4w1FIS0BqVFI2c1jZvb/uDVJijJjJ2ZMuPV81oVgTZ7g3BZxobplnMVvXtFWgtozdvYJ+MFWtwkM5S2HnAong==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.1"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-popper" "1.2.0"
+    "@radix-ui/react-portal" "1.1.2"
+    "@radix-ui/react-presence" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-slot" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-visually-hidden" "1.1.0"
+
+"@radix-ui/react-use-callback-ref@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz#bce938ca413675bc937944b0d01ef6f4a6dc5bf1"
+  integrity sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==
+
+"@radix-ui/react-use-controllable-state@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz#1321446857bb786917df54c0d4d084877aab04b0"
+  integrity sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-use-escape-keydown@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz#31a5b87c3b726504b74e05dac1edce7437b98754"
+  integrity sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-use-layout-effect@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz#3c2c8ce04827b26a39e442ff4888d9212268bd27"
+  integrity sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==
+
+"@radix-ui/react-use-rect@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz#13b25b913bd3e3987cc9b073a1a164bb1cf47b88"
+  integrity sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==
+  dependencies:
+    "@radix-ui/rect" "1.1.0"
+
+"@radix-ui/react-use-size@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz#b4dba7fbd3882ee09e8d2a44a3eed3a7e555246b"
+  integrity sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-visually-hidden@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.0.tgz#ad47a8572580f7034b3807c8e6740cd41038a5a2"
+  integrity sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.0"
+
+"@radix-ui/rect@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.0.tgz#f817d1d3265ac5415dadc67edab30ae196696438"
+  integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
 
 "@rollup/plugin-commonjs@26.0.1":
   version "26.0.1"


### PR DESCRIPTION
# 📝작업 내용
최종 결과 차트 컴포넌트를 구현했습니다.
- chart.js 사용 없이 직접 Bar 그래프를 구현했습니다.
- 미참여자는 고려하지 않았습니다.
     - 해당 이유는 밑에서 스크린 샷과 함께 설명하겠습니다.
- 툴팁 컴포넌트를 사용하여 각 후보의  퍼센티지를 툴팁으로 표기했습니다.
- ~~테스트 케이스는 빠른 시일 내에 추가하겠습니다.~~ -> **12/4 추가 완료**
# 📷스크린샷(필요 시)
**+) 12/4 최종 디자인 수정 버전**
![image](https://github.com/user-attachments/assets/607a0a43-eb2a-4e86-90ab-a4070a57fc3a)
- 투표수 총합 0인 경우 흰색 바탕의 바를 보여주도록 예외처리 했습니다.
- 바의 높이와 간격을 줄여 10개가 한번에 보일 수 있도록 수정했습니다.
- 버튼 `variant`를 `secondary`로 수정했습니다.
---

![image](https://github.com/user-attachments/assets/9f2acd48-3228-4cdb-afd8-9005576a3d90)

라운드가 많아서 한번에 다 안보이는 경우 스크롤 됩니다.

![image](https://github.com/user-attachments/assets/4b21aec9-0a77-404c-8213-f7fb400b0c68)

Hover시 해당 후보의 투표 비율을 알려주는 툴팁이 뜹니다.

![image](https://github.com/user-attachments/assets/6bc9be6c-0985-4fa4-a1cf-d79617e9e91d)

해당 시안은 미참여자 비율도 Bar 그래프에 표기한 케이스입니다.
두 후보 중 하나의 후보의 투표수가 0인 경우, 3번째 Bar 그래프처럼 마치 사과가 투표수 1인 것 처럼 혼란을 야기시킨다고 판단했습니다. 
따라서 최종 결과 차트에서는 미참여자를 고려하지 않고 밸런스게임 후보 2개의 투표수에 대해서만 표기합니다.

# ✨PR Point
- 기타 반영했으면 하는 점들 생각나는대로 말씀해주세요!!