### PR TITLE
닉네임 모달 수정 1차

### DIFF
--- a/src/components/ModalList/CreateUserNameModal.tsx
+++ b/src/components/ModalList/CreateUserNameModal.tsx
@@ -51,6 +51,11 @@ const CreateUserNameModal = () => {
         description: '기존 닉네임과 다른 닉네임을 입력해주세요.',
       });
     } else {
+      toast({
+        variant: 'success',
+        title: '닉네임 변경 성공',
+        description: `${values.username}님, 그루파이별에 오신 것을 환영해요!`,
+      });
       setMyName(values.username);
       setItem(STORAGE_KEY.NICKNAME, values.username);
       closeModal();

--- a/src/components/ModalList/CreateUserNameModal.tsx
+++ b/src/components/ModalList/CreateUserNameModal.tsx
@@ -1,17 +1,18 @@
 import {
-  ModalShell,
+  Button,
   Form,
+  FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
-  Input,
-  FormControl,
-  FormDescription,
   FormMessage,
-  Button,
+  Input,
+  ModalShell,
 } from '@/components';
 import { STORAGE_KEY } from '@/constants/storage';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { useToast } from '@/hooks/useToast';
 import useModalStore from '@/store/useModalStore';
 import useRoomStore from '@/store/useRoomStore';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -21,11 +22,13 @@ import { z } from 'zod';
 const CreateUserNameModal = () => {
   const { closeModal } = useModalStore();
   const { setItem } = useLocalStorage();
-  const { setMyName } = useRoomStore();
+  const { myName, setMyName } = useRoomStore();
+  const { toast } = useToast();
 
   const formSchema = z.object({
     username: z
       .string()
+      .trim()
       .min(2, {
         message: '닉네임은 최소 2글자 이상이어야 해요.',
       })
@@ -42,9 +45,16 @@ const CreateUserNameModal = () => {
   });
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
-    setMyName(values.username);
-    setItem(STORAGE_KEY.NICKNAME, values.username);
-    closeModal();
+    if (values.username === myName) {
+      toast({
+        title: '[알림] 닉네임 중복',
+        description: '기존 닉네임과 다른 닉네임을 입력해주세요.',
+      });
+    } else {
+      setMyName(values.username);
+      setItem(STORAGE_KEY.NICKNAME, values.username);
+      closeModal();
+    }
   };
 
   return (
@@ -63,7 +73,7 @@ const CreateUserNameModal = () => {
                 <FormLabel>닉네임</FormLabel>
                 <FormControl>
                   <Input
-                    placeholder="닉네임"
+                    placeholder={myName}
                     {...field}
                   />
                 </FormControl>

--- a/src/components/ModalList/CreateUserNameModal.tsx
+++ b/src/components/ModalList/CreateUserNameModal.tsx
@@ -75,7 +75,9 @@ const CreateUserNameModal = () => {
             name="username"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>닉네임</FormLabel>
+                <FormLabel className="text-title2 pb-400">
+                  닉네임 변경하기
+                </FormLabel>
                 <FormControl>
                   <Input
                     placeholder={myName}
@@ -87,7 +89,19 @@ const CreateUserNameModal = () => {
               </FormItem>
             )}
           />
-          <Button type="submit">변경하기</Button>
+          <span className="text-subtitle text-gray-400">
+            * 안전을 위해 개인 정보를 포함하지 마세요!
+          </span>
+          <section className="text-end">
+            <Button type="submit">변경하기</Button>
+            <Button
+              variant="secondary"
+              className="ml-300"
+              onClick={closeModal}
+            >
+              닫기
+            </Button>
+          </section>
         </form>
       </Form>
     </ModalShell>


### PR DESCRIPTION
# 📝작업 내용
모달에 기존 닉네임을 보여주는 기능을 추가했습니다.
- [x] 기존 닉네임을 placeholder로 보여줍니다.
- [x] 기존 닉네임과 같은 닉네임을 입력하면 토스트를 띄웁니다.
- [x] 닉네임 변경에 성공하면 토스트를 띄웁니다.
- [x] 유효성 검사 조건(formSchema)에 trim을 추가했습니다.
- [x] 개인 정보 입력 안전 문구를 추가했습니다.
- [x] 간격, 텍스트, 위치 등 모달 CSS를 수정했습니다.

# 📷스크린샷
![placeholder](https://github.com/user-attachments/assets/1bf659b5-628e-4b9e-b9a3-384fa422792e)
![중복토스트](https://github.com/user-attachments/assets/d7d6d623-110d-4015-b874-2c7ef88abbab)
![성공토스트](https://github.com/user-attachments/assets/307a73bf-e70a-49e5-8aac-181a2cec16cd)

# ✨PR Point
`CreateUserNameModal.tsx` 한 파일 수정으로 리뷰 시간은 오래 안 걸립니다!