### PR TITLE
부분 결과 컴포넌트 1차 수정

### DIFF
--- a/src/app/balance-game/[roomId]/PrevGame.tsx
+++ b/src/app/balance-game/[roomId]/PrevGame.tsx
@@ -1,16 +1,16 @@
-import { GameListCard, Button } from '@/components';
+import { Button, GameListCard } from '@/components';
 import { SOCKET } from '@/constants/websocket';
+import { useToast } from '@/hooks/useToast';
+import useBalanceGameStore from '@/store/useBalanceGameStore';
+import useRoomStore from '@/store/useRoomStore';
 import { Player, RoomGetResponse } from '@/types/api';
+import * as StompJS from '@stomp/stompjs';
 import {
   CheckCheck,
   Loader,
-  SlidersHorizontal,
   MousePointer2,
+  SlidersHorizontal,
 } from 'lucide-react';
-import * as StompJS from '@stomp/stompjs';
-import useBalanceGameStore from '@/store/useBalanceGameStore';
-import useRoomStore from '@/store/useRoomStore';
-import { useToast } from '@/hooks/useToast';
 
 interface PrevGameProps {
   roomDetail: RoomGetResponse;
@@ -75,7 +75,7 @@ const PrevGame = ({
   };
 
   return (
-    <section className="w-full h-full flex flex-col justify-center items-center gap-7">
+    <section className="w-full h-full flex flex-col justify-center items-center gap-7 px-900">
       <span className="font-semibold">잠시 후 게임이 시작됩니다.</span>
       <GameListCard
         title={roomDetail.game.nameKr}

--- a/src/app/balance-game/[roomId]/page.tsx
+++ b/src/app/balance-game/[roomId]/page.tsx
@@ -8,25 +8,24 @@ import {
   Spinner,
   UserInfoCard,
 } from '@/components';
+import BalanceGameProgress from '@/components/BalanceGameProgress';
+import { BarProps } from '@/components/FinalResultChart/Bar';
 import { QUERYKEY } from '@/constants/querykey';
 import { PATH } from '@/constants/router';
+import { SOCKET } from '@/constants/websocket';
 import useFetchRoomDetail from '@/hooks/useFetchRoomDetail';
 import { useToast } from '@/hooks/useToast';
 import { useWebSocket } from '@/hooks/useWebSocket';
+import { getBalanceGameResults } from '@/services/balanceGames';
+import useBalanceGameStore from '@/store/useBalanceGameStore';
 import useModalStore from '@/store/useModalStore';
+import useRoomStore from '@/store/useRoomStore';
 import { BalanceGameResultGetResponse, Player } from '@/types/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { Link } from 'lucide-react';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import PrevGame from './PrevGame';
-import BalanceGameProgress from '@/components/BalanceGameProgress';
-import useBalanceGameStore from '@/store/useBalanceGameStore';
-import { SOCKET } from '@/constants/websocket';
-import { BarProps } from '@/components/FinalResultChart/Bar';
-import useRoomStore from '@/store/useRoomStore';
-import { useRouter } from 'next/navigation';
-import { getBalanceGameResults } from '@/services/balanceGames';
 
 const WaitingRoom = () => {
   const path = usePathname();
@@ -157,7 +156,7 @@ const WaitingRoom = () => {
         ))}
       </section>
 
-      <section className="h-4/5 min-w-[45rem] max-w-[70rem] w-full bg-container/50 rounded-lg">
+      <section className="h-4/5 min-w-max max-w-[70rem] w-full bg-container/50 rounded-lg">
         {roomStatus === 'idle' && (
           <PrevGame
             roomDetail={roomDetail}

--- a/src/components/PartialResultChart/PartialResultChart.tsx
+++ b/src/components/PartialResultChart/PartialResultChart.tsx
@@ -2,19 +2,11 @@
 
 import { PieChart } from '@/components';
 import useBalanceGameStore from '@/store/useBalanceGameStore';
+import { BalanceGameResultGetResponse } from '@/types/api';
+import { UserList } from '.';
 
 interface PartialResultChartProps {
-  data: {
-    round: number;
-    q: string;
-    a: string;
-    b: string;
-    result: {
-      a: string[];
-      b: string[];
-      c: string[];
-    };
-  }[];
+  data: BalanceGameResultGetResponse[];
 }
 
 const PartialResultChart = ({ data }: PartialResultChartProps) => {
@@ -26,59 +18,38 @@ const PartialResultChart = ({ data }: PartialResultChartProps) => {
     partialData.result.c.length,
   ];
   const chartLabels = [partialData.a, partialData.b, UNSELECTED];
+
   const { totalRounds } = useBalanceGameStore();
 
   return (
-    <section className="bg-container-600 h-full w-full border-white/50 flex flex-col justify-center items-center rounded-lg gap-8 p-8">
+    <section className="bg-container-600 h-full w-full min-w-fit border-white/50 flex flex-col justify-between items-center rounded-lg gap-8 p-8">
       <section>
-        <h1 className="text-title1 font-semibold">
+        <h1 className="pt-600 text-title1 font-semibold">
           {partialData.round}라운드 결과
         </h1>
       </section>
-      <section className="flex items-stretch gap-700">
-        <section className="selected-a bg-primary/20 py-500 px-400 rounded-sm flex flex-col gap-300 items-center">
-          <h1 className="text-title2">{partialData.a}</h1>
-          <hr className="w-full border-white/50" />
-          <section className="flex flex-col gap-300 items-center">
-            {partialData.result.a.map((user, index) => (
-              <span
-                key={user + index}
-                className="text-body1"
-              >
-                {user}
-              </span>
-            ))}
-          </section>
-        </section>
+      <section className="flex justify-between items-stretch gap-700">
+        <UserList
+          title={partialData.a}
+          data={partialData.result.a}
+          className={'selected-a bg-primary/20'}
+        />
         <PieChart
           labels={chartLabels}
           data={chartData}
         />
-        <section className="selected-b bg-secondary/20 py-500 px-400 rounded-sm flex flex-col gap-300 items-center">
-          <h1 className="text-title2">{partialData.b}</h1>
-          <hr className="w-full border-white/50 border-white/50" />
-          <section className="flex flex-col gap-300 items-center">
-            {partialData.result.b.map((user, index) => (
-              <span
-                key={user + index}
-                className="text-body1"
-              >
-                {user}
-              </span>
-            ))}
-          </section>
-        </section>
+        <UserList
+          title={partialData.b}
+          data={partialData.result.b}
+          className={'selected-b bg-secondary/20'}
+        />
       </section>
       {partialData.result.c.length !== 0 && (
-        <section className="selected-c w-full bg-container-700/70 py-500 px-500 rounded-sm flex flex-col gap-300 items-center">
-          <h1 className="text-title2">{UNSELECTED}</h1>
-          <hr className="w-full border-white/50" />
-          <section className="flex flex-col gap-300 items-center">
-            <span className="text-body1">
-              {partialData.result.c.join(', ')}
-            </span>
-          </section>
-        </section>
+        <UserList
+          title={UNSELECTED}
+          data={partialData.result.c.join(', ')}
+          className="selected-c w-full bg-container-700/70"
+        />
       )}
       <section className="self-end">
         {partialData.round} / {totalRounds}

--- a/src/components/PartialResultChart/PartialResultChart.tsx
+++ b/src/components/PartialResultChart/PartialResultChart.tsx
@@ -22,7 +22,7 @@ const PartialResultChart = ({ data }: PartialResultChartProps) => {
   const { totalRounds } = useBalanceGameStore();
 
   return (
-    <section className="bg-container-600 h-full w-full min-w-fit border-white/50 flex flex-col justify-between items-center rounded-lg gap-8 p-8">
+    <section className="bg-container-600 h-full w-full min-h-fit border-white/50 flex flex-col justify-between items-center rounded-lg gap-8 p-8">
       <section>
         <h1 className="pt-600 text-title1 font-semibold">
           {partialData.round}라운드 결과

--- a/src/components/PartialResultChart/UserList.tsx
+++ b/src/components/PartialResultChart/UserList.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils';
+import React from 'react';
+
+interface UserListProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string;
+  data: string[] | string;
+  className?: string;
+}
+
+const UserList = ({ title, data, className, ...props }: UserListProps) => {
+  return (
+    <section
+      className={cn(
+        'min-w-[13rem] py-500 px-400 rounded-sm flex flex-col gap-300 items-center',
+        className
+      )}
+      {...props}
+    >
+      <h1 className="text-title2">{title}</h1>
+      <hr className="w-full border-white/50" />
+      <section className="flex flex-col gap-300 items-center">
+        {typeof data === 'string'
+          ? data
+          : data.map((user, index) => (
+              <span
+                key={user + index}
+                className="text-body1"
+              >
+                {user}
+              </span>
+            ))}
+      </section>
+    </section>
+  );
+};
+
+export default UserList;

--- a/src/components/PartialResultChart/UserList.tsx
+++ b/src/components/PartialResultChart/UserList.tsx
@@ -11,7 +11,7 @@ const UserList = ({ title, data, className, ...props }: UserListProps) => {
   return (
     <section
       className={cn(
-        'min-w-[13rem] py-500 px-400 rounded-sm flex flex-col gap-300 items-center',
+        'min-w-[13rem] max-w-[54rem] py-500 px-400 rounded-sm flex flex-col gap-300 items-center',
         className
       )}
       {...props}

--- a/src/components/PartialResultChart/index.ts
+++ b/src/components/PartialResultChart/index.ts
@@ -1,1 +1,2 @@
 export { default as PartialResultChart } from './PartialResultChart';
+export { default as UserList } from './UserList';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -28,8 +28,8 @@ export { default as Logo } from './Logo';
 export { MainHeader } from './MainHeader';
 export { ModalRenderer, ModalShell } from './Modal';
 export { Navigation } from './Navigation';
+export { PartialResultChart, UserList } from './PartialResultChart';
 export { PieChart } from './PieChart';
-export { PartialResultChart } from './PartialResultChart';
 export { ShootingStars, StarsBackground } from './ShootingStars';
 export { Slider } from './Slider';
 export { Spinner } from './Spinner';
@@ -39,17 +39,17 @@ export {
   ToastAction,
   ToastClose,
   ToastDescription,
-  Toaster,
   ToastProvider,
   ToastTitle,
   ToastViewport,
+  Toaster,
   type ToastActionElement,
   type ToastProps,
 } from './Toast';
 export {
   Tooltip,
-  TooltipTrigger,
   TooltipContent,
   TooltipProvider,
+  TooltipTrigger,
 } from './Tooltip';
 export { default as UserInfoCard } from './UserInfoCard';


### PR DESCRIPTION
# 📝작업 내용
PR 내용을 반영하여 다음 사항을 수정했습니다.

⚠️ 컴포넌트 export 파일이 `index.tsx`에서 `index.ts`로 확장자가 변경되었습니다.
- [x] 기존 인터페이스(BalanceGameResultGetResponse)를 재사용합니다.
- [x] UserList 컴포넌트로 분리합니다.
- [x] 레이아웃 CSS를 수정합니다. (min, max)

# 📷스크린샷
최소 너비
![image](https://github.com/user-attachments/assets/4d88a09e-4deb-40cd-8522-9164c6c9c38f)
최대 너비
![image](https://github.com/user-attachments/assets/e49b9b30-4118-4e98-ab8b-42e35436a02a)

# ✨PR Point
- balance-game 페이지에서 게임중 컴포넌트를 감싸는 section의 `min-w-[45rem]` 고정값을 `min-w-max`로 수정했습니다. 하위 컴포넌트 width 계산 시 45rem을 초과할 때 콘텐츠가 바깥으로 나오는 문제를 수정했습니다.