### PR TITLE
핫픽스: ws 에러 구독 주소에서 topic경로 제거

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -66,7 +66,7 @@ export function useWebSocket() {
       );
 
       const subscribeErrorId = client.current?.subscribe(
-        `${SOCKET.ENDPOINT.SUBSCRIBE}${SOCKET.ENDPOINT.USER.QUEUE_ERRORS}`,
+        `${SOCKET.ENDPOINT.USER.QUEUE_ERRORS}`,
         (message) => {
           console.log(
             '[WebSocket] 2. Subscribe2 - Receive Message',


### PR DESCRIPTION
# 📝작업 내용
ws 에러 구독 주소에서 topic경로가 불필요하게 추가되어 있어서 에러 메세지가 수신되지 않는 현상 해결