### PR TITLE
준비 상태일 때 닉네임 변경 버튼 삭제

### DIFF
--- a/src/app/balance-game/[roomId]/_component/UserList.tsx
+++ b/src/app/balance-game/[roomId]/_component/UserList.tsx
@@ -41,7 +41,8 @@ const UserList = ({ players }: UserListProps) => {
         <UserInfoCard
           key={player.name}
           name={player.name}
-          isReady={roomStatus === 'idle' ? player.isReady : false}
+          isReady={player.isReady}
+          isStart={roomStatus !== 'idle'}
           fileName={player.avatar}
           isHost={player.isHost}
         />

--- a/src/components/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/UserInfoCard/UserInfoCard.tsx
@@ -11,6 +11,7 @@ import { Button } from '../Button';
 interface UserInfoCardProps {
   name: string;
   isReady: boolean;
+  isStart: boolean;
   isHost: boolean;
   fileName: string;
 }
@@ -18,6 +19,7 @@ interface UserInfoCardProps {
 const UserInfoCard = ({
   name,
   isReady,
+  isStart,
   isHost,
   fileName,
 }: UserInfoCardProps) => {
@@ -32,6 +34,7 @@ const UserInfoCard = ({
     <section
       className={cn(
         isReady ? 'bg-primary/50' : 'bg-container',
+        isStart && 'bg-container',
         'w-full h-[4rem] flex rounded-lg relative'
       )}
     >
@@ -59,7 +62,7 @@ const UserInfoCard = ({
         <span className={cn(myName === name && 'text-primary-400')}>
           {name}
         </span>
-        {name === myName && (
+        {name === myName && !isReady && (
           <Button
             variant="ghost"
             size="icon"


### PR DESCRIPTION
closes #176 

# 📝작업 내용
- 준비상태일 때 닉네임 변경 불가능하므로 버튼 삭제
- 게임 시작했을 때 강제로 ready=false로 변경해주던 기존 로직과 충돌하여 isStart props 추가하여 해결

# 📷스크린샷(필요 시)
게임 시작했을 때
![image](https://github.com/user-attachments/assets/2958c842-7e31-41dd-b6d7-2a978ea1356f)
UNREADY 상태 
![image](https://github.com/user-attachments/assets/6581ec2e-fe0d-4a2a-9cf7-098587fe245e)
READY 상태
![image](https://github.com/user-attachments/assets/2e05a78d-2f6b-4610-a4fc-0110ddf34934)


# ✨PR Point
- 방장의 경우 항상 준비상태이기 때문에 닉네임 변경을 하지 못하는데, 이 로직을 그대로 두어도 될까요 아니면 개선이 필요할까요?