### PR TITLE
Qna 게임 결과 페이지네이션

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,133 @@
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from 'lucide-react';
+import Link from 'next/link';
+import * as React from 'react';
+
+import { Button, buttonVariants } from '@/components/Button';
+import { cn } from '@/lib/utils';
+
+function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn('mx-auto flex w-full justify-center', className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<'ul'>) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn('flex flex-row items-center gap-1', className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
+  return (
+    <li
+      data-slot="pagination-item"
+      {...props}
+    />
+  );
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, 'size'> &
+  React.ComponentProps<typeof Link>;
+
+function PaginationLink({
+  className,
+  isActive,
+  size = 'icon',
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <Link
+      aria-current={isActive ? 'page' : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? 'outline' : 'ghost',
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn('gap-1 px-2.5 sm:pl-2.5', className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Prev</span>
+    </PaginationLink>
+  );
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn('gap-1 px-2.5 sm:pr-2.5', className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  );
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn('flex size-9 items-center justify-center', className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  );
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+};

--- a/src/components/Pagination/index.ts
+++ b/src/components/Pagination/index.ts
@@ -1,0 +1,9 @@
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from './Pagination';

--- a/src/components/QnaGame/QnaGameFinalResult.tsx
+++ b/src/components/QnaGame/QnaGameFinalResult.tsx
@@ -23,8 +23,8 @@ const QnaGameFinalResult = ({
   results,
   className,
 }: QnaGameFinalResultProps) => {
-  const [page, setPage] = useState(1);
-  const roundResult = results[page - 1];
+  const [round, setRound] = useState(1);
+  const roundResult = results[round - 1];
 
   if (!results || results.length === 0) {
     return (
@@ -41,38 +41,35 @@ const QnaGameFinalResult = ({
         className
       )}
     >
-      <section className="h-full overflow-y-auto p-8 pr-6 rounded-lg space-y-6">
-        <h4 className="text-center text-h4 mb-6">최종 결과</h4>
+      <section className="flex flex-col h-full p-6 rounded-lg gap-3">
+        <h4 className="text-center text-h4">최종 결과 - {round} 라운드</h4>
 
-        <section>
-          <span className="text-title1">Q. {roundResult.question}</span>
+        <span className="text-title1">Q. {roundResult.question}</span>
 
-          <section className="space-y-2 mt-2">
-            {roundResult.result.length > 0 ? (
-              roundResult.result
-                .sort((current, next) => next.likes - current.likes)
-                .map((item, itemIndex) => (
-                  <QnaGameUserFinalResult
-                    key={`answer-${item.name}-${itemIndex}`}
-                    user={item}
-                  />
-                ))
-            ) : (
-              <div className="p-3 bg-container-700/50 rounded-xl text-center">
-                <span className="text-base">
-                  엇, 무언가 잘못됐어요. 결과가 없어요..T_T
-                </span>
-              </div>
-            )}
-          </section>
+        <section className="h-full space-y-2 overflow-y-auto">
+          {roundResult.result.length > 0 ? (
+            roundResult.result
+              .sort((current, next) => next.likes - current.likes)
+              .map((item, itemIndex) => (
+                <QnaGameUserFinalResult
+                  key={`answer-${item.name}-${itemIndex}`}
+                  user={item}
+                />
+              ))
+          ) : (
+            <div className="p-3 bg-container-700/50 rounded-xl text-center">
+              <span className="text-base">
+                엇, 무언가 잘못됐어요. 결과가 없어요..T_T
+              </span>
+            </div>
+          )}
         </section>
-
         <Pagination>
           <PaginationContent>
             <PaginationItem>
               <PaginationPrevious
                 href="#"
-                onClick={() => setPage(Math.max(1, page - 1))}
+                onClick={() => setRound(Math.max(1, round - 1))}
               />
             </PaginationItem>
 
@@ -80,8 +77,8 @@ const QnaGameFinalResult = ({
               <PaginationItem key={result.round}>
                 <PaginationLink
                   href="#"
-                  onClick={() => setPage(result.round)}
-                  isActive={page == result.round}
+                  onClick={() => setRound(result.round)}
+                  isActive={round == result.round}
                 >
                   {index + 1}
                 </PaginationLink>
@@ -91,7 +88,7 @@ const QnaGameFinalResult = ({
             <PaginationItem>
               <PaginationNext
                 href="#"
-                onClick={() => setPage(Math.min(results.length, page + 1))}
+                onClick={() => setRound(Math.min(results.length, round + 1))}
               />
             </PaginationItem>
           </PaginationContent>

--- a/src/components/QnaGame/QnaGameFinalResult.tsx
+++ b/src/components/QnaGame/QnaGameFinalResult.tsx
@@ -1,9 +1,19 @@
 'use client';
 
-import { Heart } from 'lucide-react';
+import { useState } from 'react';
 
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components';
 import { cn } from '@/lib/utils';
 import { QnaGameResultGetResponse } from '@/types/api';
+
+import QnaGameUserFinalResult from './QnaGameUserFinalResult';
 interface QnaGameFinalResultProps {
   results: QnaGameResultGetResponse[];
   className?: string;
@@ -13,6 +23,9 @@ const QnaGameFinalResult = ({
   results,
   className,
 }: QnaGameFinalResultProps) => {
+  const [page, setPage] = useState(1);
+  const roundResult = results[page - 1];
+
   if (!results || results.length === 0) {
     return (
       <div className="w-full text-center p-8">
@@ -31,51 +44,58 @@ const QnaGameFinalResult = ({
       <section className="h-full overflow-y-auto p-8 pr-6 rounded-lg space-y-6">
         <h4 className="text-center text-h4 mb-6">최종 결과</h4>
 
-        {results.map((roundResult, index) => (
-          <section key={`round-${roundResult.round}-${index}`}>
-            <span className="text-title1">Q. {roundResult.question}</span>
+        <section>
+          <span className="text-title1">Q. {roundResult.question}</span>
 
-            <div className="space-y-2 mt-2">
-              {roundResult.result.length > 0 ? (
-                roundResult.result
-                  .sort((current, next) => next.likes - current.likes)
-                  .map((item, itemIndex) => (
-                    <div
-                      key={`answer-${item.name}-${itemIndex}`}
-                      className="flex items-center p-3 bg-primary/10 rounded-xl min-h-3"
-                    >
-                      <div className="flex flex-col items-center justify-center min-w-14">
-                        <Heart className="w-6 h-6 fill-current text-secondary-500" />
-                        <span className="text-title3">{item.likes}</span>
-                      </div>
-
-                      <div className="p-2 w-36">
-                        <span className="text-body2 font-medium opacity-80 block">
-                          {item.name}
-                        </span>
-                      </div>
-
-                      <div className="text-secondary-500/70 mr-3 flex items-center self-stretch">
-                        <div className="h-full w-px bg-gray-400/50" />
-                      </div>
-
-                      <div className="flex-1 min-w-44">
-                        <span className="text-body1 text-base break-words whitespace-pre-wrap">
-                          {item.answer}
-                        </span>
-                      </div>
-                    </div>
-                  ))
-              ) : (
-                <div className="p-3 bg-container-700/50 rounded-xl text-center">
-                  <span className="text-base">
-                    엇, 무언가 잘못됐어요. 결과가 없어요..T_T
-                  </span>
-                </div>
-              )}
-            </div>
+          <section className="space-y-2 mt-2">
+            {roundResult.result.length > 0 ? (
+              roundResult.result
+                .sort((current, next) => next.likes - current.likes)
+                .map((item, itemIndex) => (
+                  <QnaGameUserFinalResult
+                    key={`answer-${item.name}-${itemIndex}`}
+                    user={item}
+                  />
+                ))
+            ) : (
+              <div className="p-3 bg-container-700/50 rounded-xl text-center">
+                <span className="text-base">
+                  엇, 무언가 잘못됐어요. 결과가 없어요..T_T
+                </span>
+              </div>
+            )}
           </section>
-        ))}
+        </section>
+
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={() => setPage(Math.max(1, page - 1))}
+              />
+            </PaginationItem>
+
+            {results.map((result, index) => (
+              <PaginationItem key={result.round}>
+                <PaginationLink
+                  href="#"
+                  onClick={() => setPage(result.round)}
+                  isActive={page == result.round}
+                >
+                  {index + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={() => setPage(Math.min(results.length, page + 1))}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
       </section>
     </main>
   );

--- a/src/components/QnaGame/QnaGamePartialResult.tsx
+++ b/src/components/QnaGame/QnaGamePartialResult.tsx
@@ -6,7 +6,7 @@ import { SOCKET } from '@/constants/websocket';
 import useQnaGameStore from '@/store/useQnaGameStore';
 import { QnaGameResultGetResponse } from '@/types/api';
 
-import QnaUserResult from './QnaGameUserResult';
+import QnaGameUserPartialResult from './QnaGameUserPartialResult';
 
 interface QnaGamePartialResultProps {
   data: QnaGameResultGetResponse[];
@@ -51,7 +51,7 @@ const QnaGamePartialResult = ({
         <h3 className="text-title1 mb-500">Q. {question}</h3>
         <section className="flex flex-col gap-400">
           {result.map((result, index) => (
-            <QnaUserResult
+            <QnaGameUserPartialResult
               key={result.name + index}
               result={result}
               onLike={handleClickLike}

--- a/src/components/QnaGame/QnaGameUserFinalResult.tsx
+++ b/src/components/QnaGame/QnaGameUserFinalResult.tsx
@@ -1,0 +1,36 @@
+import { Heart } from 'lucide-react';
+
+import { QnaGameAnswerResponse } from '@/types/api';
+
+interface QnaGameUserFinalResultProps {
+  user: QnaGameAnswerResponse;
+}
+
+const QnaGameUserFinalResult = ({ user }: QnaGameUserFinalResultProps) => {
+  return (
+    <section className="flex items-center p-3 bg-primary/10 rounded-xl min-h-3">
+      <div className="flex flex-col items-center justify-center min-w-14">
+        <Heart className="w-6 h-6 fill-current text-secondary-500" />
+        <span className="text-title3">{user.likes}</span>
+      </div>
+
+      <div className="p-2 w-36">
+        <span className="text-body2 font-medium opacity-80 block">
+          {user.name}
+        </span>
+      </div>
+
+      <div className="text-secondary-500/70 mr-3 flex items-center self-stretch">
+        <div className="h-full w-px bg-gray-400/50" />
+      </div>
+
+      <div className="flex-1 min-w-44">
+        <span className="text-body1 text-base break-words whitespace-pre-wrap">
+          {user.answer}
+        </span>
+      </div>
+    </section>
+  );
+};
+
+export default QnaGameUserFinalResult;

--- a/src/components/QnaGame/QnaGameUserPartialResult.tsx
+++ b/src/components/QnaGame/QnaGameUserPartialResult.tsx
@@ -12,7 +12,7 @@ interface QnaGameUserResultProps {
   onUnlike: (receiver: string) => void;
 }
 
-const QnaGameUserResult = ({
+const QnaGameUserPartialResult = ({
   result,
   onLike,
   onUnlike,
@@ -51,4 +51,4 @@ const QnaGameUserResult = ({
   );
 };
 
-export default QnaGameUserResult;
+export default QnaGameUserPartialResult;

--- a/src/components/QnaGame/index.ts
+++ b/src/components/QnaGame/index.ts
@@ -5,4 +5,5 @@ export { default as QnaGamePartialResult } from './QnaGamePartialResult';
 export { default as QnaGameProgress } from './QnaGameProgress';
 export { default as QnaGameQuestionPanel } from './QnaGameQuestionPanel';
 export { default as QnaGameResultsFetcher } from './QnaGameResultsFetcher';
-export { default as QnaGameUserResult } from './QnaGameUserResult';
+export { default as QnaGameUserFinalResult } from './QnaGameUserFinalResult';
+export { default as QnaGameUserPartialResult } from './QnaGameUserPartialResult';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -52,7 +52,8 @@ export {
   QnaGameProgress,
   QnaGameQuestionPanel,
   QnaGameResultsFetcher,
-  QnaGameUserResult,
+  QnaGameUserFinalResult,
+  QnaGameUserPartialResult,
 } from './QnaGame';
 export { ShootingStars, StarsBackground } from './ShootingStars';
 export { Slider } from './Slider';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -33,6 +33,15 @@ export { default as Logo } from './Logo';
 export { MainHeader, Nicknamebar } from './MainHeader';
 export { ModalRenderer, ModalShell } from './Modal';
 export { Navigation } from './Navigation';
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from './Pagination';
 export { PartialResultChart, UserList } from './PartialResultChart';
 export { PieChart } from './PieChart';
 export {


### PR DESCRIPTION
# 📝작업 내용
Qna 게임의 각 라운드 별 결과를 보기 쉽도록 페이지네이션 적용했습니다.
- shadcn Pagination 컴포넌트 추가
- QnaGameFinalResult 컴포넌트에 페이지네이션 적용
# 📷스크린샷(필요 시)
![image](https://github.com/user-attachments/assets/a54836a9-b89b-4939-8b4b-77cdf8be4072)
- Prev, Next 버튼으로 이동도 가능합니다.
# ✨PR Point
- 임의로 UI를 이렇게 잡았는데, 혹시 더 개선사항이 필요한 점 있다면 리뷰해주세요!