### PR TITLE
테스트 코드 에러 수정(GameListCard, Toast)

### DIFF
--- a/src/components/GameListCard/GameListCard.test.tsx
+++ b/src/components/GameListCard/GameListCard.test.tsx
@@ -1,11 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import Image from 'next/image';
 import { describe, expect, test, vi } from 'vitest';
 
 import { GameListCard } from './';
 
 describe('GameListCard', () => {
-  test('1) title, description이 잘 렌더링된다.', () => {
+  test('1) title, description를 전달하면 렌더링된다.', () => {
     render(
       <GameListCard
         title="game"
@@ -16,11 +15,11 @@ describe('GameListCard', () => {
     expect(screen.getByText('game')).toBeInTheDocument();
     expect(screen.getByText("game's description")).toBeInTheDocument();
   });
-  test('2) src를 전달하면 Image가 렌더링된다.', () => {
+  test('2) src를 전달하면 img가 렌더링된다.', () => {
     vi.mock('next/image', () => ({
       __esModule: true,
       default: ({ src, alt }: { src: string; alt: string }) => (
-        <Image
+        <img
           src={src}
           alt={alt}
         />
@@ -38,7 +37,7 @@ describe('GameListCard', () => {
     const image = screen.getByAltText('game');
     expect(image).toHaveAttribute('alt', 'game');
   });
-  test('3) className를 전달하면 잘 렌더링된다.', () => {
+  test('3) className를 전달하면 스타일이 렌더링된다.', () => {
     render(
       <GameListCard
         title="game"

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -1,5 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 
 import { ToastAction, ToastActionElement, Toaster } from '@/components';
@@ -87,7 +86,9 @@ describe('Toast 컴포넌트', () => {
       const toast = screen.getAllByText('Test Toast')[0];
       expect(toast).toBeInTheDocument();
 
-      await new Promise((resolve) => setTimeout(resolve, TOAST_TIMEOUT));
+      await act(
+        () => new Promise((resolve) => setTimeout(resolve, TOAST_TIMEOUT))
+      );
       expect(toast).not.toBeInTheDocument();
     },
     TEST_TIMEOUT


### PR DESCRIPTION
close #172 

# 📝작업 내용
테스트 실패 오류를 수정합니다.
- [x] GameListCard 테스트 수정 : Image 대신 img 사용하기
- [x] Toast 테스트 수정 : setTimeout act()로 감싸기

# ✨PR Point
간단한 테스트 코드 수정으로 빠른 리뷰 가능합니다!