### PR TITLE
웹소켓 방장 EXIT 2번 전송 현상 수정

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -97,9 +97,6 @@ export function useWebSocket() {
 
   const disconnect = () => {
     if (!client.current) return;
-    sendMessage({
-      destination: `${SOCKET.ROOM.EXIT}`,
-    });
 
     subscriptions?.forEach((subscription) => subscription.unsubscribe());
     client.current.deactivate();


### PR DESCRIPTION
close #193 

# 📝작업 내용
웹소켓에서 방장 퇴장 시 게스트들에게 EXIT 메세지를 2번 전송하는 현상을 수정합니다.

원인 분석 결과, 하나는 프론트엔드, 하나는 서버에서 전송한 것임을 확인했습니다.
서버에서 소켓 연결이 끊기는 것을 감지하여 퇴장하는 방어코드가 있기 때문에 프론트엔드의 EXIT 전송을 삭제하기로 결정했습니다.

# ✨PR Point
disconnect() 함수의 EXIT 메세지 전송 로직을 삭제하는 간단한 로직입니다!