### PR TITLE
Timer 로직 변경

### DIFF
--- a/src/components/BalanceGame/BalanceGameProgress.tsx
+++ b/src/components/BalanceGame/BalanceGameProgress.tsx
@@ -21,7 +21,6 @@ const BalanceGameProgress = ({
   setIsTimeout,
 }: BalanceGameProgressProps) => {
   const { round } = useBalanceGameStore();
-
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
 
   const handleSelect = (option: string) => {
@@ -42,8 +41,7 @@ const BalanceGameProgress = ({
     <main className="flex flex-col items-center justify-center p-8 h-full">
       <section className="w-full mb-4 flex flex-col items-center gap-4">
         <Timer
-          startTime={round.startTime}
-          endTime={round.endTime}
+          playSeconds={round.playSeconds}
           setIsTimeout={setIsTimeout}
         />
       </section>

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -37,7 +37,7 @@ const Timer = ({ playSeconds, setIsTimeout }: TimerProps) => {
   useEffect(() => {
     rafId.current = requestAnimationFrame(updateTimer);
     return () => cancelAnimationFrame(rafId.current);
-  }, [updateTimer]);
+  }, []);
 
   useEffect(() => {
     if (timeLeft <= 0) {

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -43,7 +43,7 @@ const Timer = ({ playSeconds, setIsTimeout }: TimerProps) => {
     if (timeLeft <= 0) {
       setIsTimeout(true);
     }
-  }, [timeLeft]);
+  }, [timeLeft, setIsTimeout]);
 
   return (
     <section className="flex items-center justify-center gap-2 w-full text-title1 font-semibold">

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -1,67 +1,49 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 
-import dayjs, { Dayjs } from 'dayjs';
-import utc from 'dayjs/plugin/utc';
 import { AlarmClock } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
-dayjs.extend(utc);
-
-type Time = string | number | Date | Dayjs;
-
 interface TimerProps {
-  startTime: Time;
-  endTime: Time;
+  playSeconds: number;
   setIsTimeout: (props: boolean) => void;
 }
 
-const Timer = ({ startTime, endTime, setIsTimeout }: TimerProps) => {
-  const localStartTime = dayjs.utc(startTime).local().valueOf();
-  const localEndTime = dayjs.utc(endTime).local().valueOf();
-
-  const totalTime = localEndTime - localStartTime;
+const Timer = ({ playSeconds, setIsTimeout }: TimerProps) => {
+  const totalTime = playSeconds * 1000;
   const [timeLeft, setTimeLeft] = useState(totalTime);
 
-  const percentage = (timeLeft / totalTime) * 100;
-  const second = Math.ceil(timeLeft / 1000);
-
   const rafId = useRef(0);
+  const startTimeRef = useRef(Date.now());
+  const endTimeRef = useRef(startTimeRef.current + totalTime);
+
+  const percentage = (timeLeft / totalTime) * 100;
+  const second = Math.max(0, Math.ceil(timeLeft / 1000));
 
   const updateTimer = () => {
     const curTime = Date.now();
 
     setTimeLeft(() => {
-      if (curTime >= localEndTime) {
+      if (curTime >= endTimeRef.current) {
         cancelAnimationFrame(rafId.current);
         return 0;
       }
-      return localEndTime - curTime;
+      return endTimeRef.current - curTime;
     });
 
     rafId.current = requestAnimationFrame(updateTimer);
   };
 
   useEffect(() => {
-    const curTime = Date.now();
-    // 시작 시간이 아직 아니라면 타이머를 대기시킨다.
-    if (curTime < localStartTime) {
-      const delay = localStartTime - curTime;
-      const timerId = setTimeout(() => {
-        rafId.current = requestAnimationFrame(updateTimer);
-        setTimeLeft(localEndTime - Date.now());
-      }, delay);
-      return () => clearTimeout(timerId);
-    } else {
-      rafId.current = requestAnimationFrame(updateTimer);
-    }
-  }, [endTime, startTime, updateTimer]);
+    rafId.current = requestAnimationFrame(updateTimer);
+    return () => cancelAnimationFrame(rafId.current);
+  }, [updateTimer]);
 
   useEffect(() => {
     if (timeLeft <= 0) {
       setIsTimeout(true);
     }
-  }, [timeLeft, setIsTimeout]);
+  }, [timeLeft]);
 
   return (
     <section className="flex items-center justify-center gap-2 w-full text-title1 font-semibold">
@@ -70,7 +52,7 @@ const Timer = ({ startTime, endTime, setIsTimeout }: TimerProps) => {
 
       <div className="w-full bg-[#5D5293] rounded h-4 overflow-hidden">
         <div
-          className="bg-primary h-full rounded "
+          className="bg-primary h-full rounded"
           style={{ width: `${percentage}%` }}
         />
       </div>

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -9,5 +9,6 @@ export const DOMAIN = {
   GET_BALANCEGAME_RESULT: '/games/balance-game/results',
   GET_NICKNAME_VALIDATION: (roomId: string) =>
     `/rooms/${roomId}/players/is-valid-name`,
+  GET_TIME: '/time',
   GET_QNAGAME_RESULT: '/games/qna-game/results',
 };

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+import { DOMAIN } from '@/constants/api';
+
+export const useSSE = () => {
+  const [time, setTime] = useState<string | null>(null);
+  const [error, setError] = useState<Event | null>(null);
+
+  useEffect(() => {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+    const getTimeUrl = `${baseUrl}${DOMAIN.GET_TIME}`;
+    const eventSource = new EventSource(getTimeUrl);
+
+    eventSource.addEventListener('time', (event) => {
+      const time = event.data.trim().replace(/^"|"$/g, '');
+      setTime(time);
+    });
+
+    eventSource.onerror = (event) => {
+      setError(event);
+      eventSource.close();
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  }, []);
+
+  return { time, error };
+};

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -18,7 +18,6 @@ export const useSSE = () => {
 
     eventSource.onerror = (event) => {
       setError(event);
-      eventSource.close();
     };
 
     return () => {

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -4,10 +4,14 @@ import { DOMAIN } from '@/constants/api';
 
 export const useSSE = () => {
   const [time, setTime] = useState<string | null>(null);
-  const [error, setError] = useState<Event | null>(null);
+  const [error, setError] = useState<Event | Error | null>(null);
 
   useEffect(() => {
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+    if (!baseUrl) {
+      setError(new Error('NEXT_PUBLIC_BASE_URL is not defined.'));
+      return;
+    }
     const getTimeUrl = `${baseUrl}${DOMAIN.GET_TIME}`;
     const eventSource = new EventSource(getTimeUrl);
 

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -3,8 +3,7 @@
 export interface BalanceGameRoundResponse {
   totalRounds: number;
   currentRound: number;
-  startTime: string;
-  endTime: string;
+  playSeconds: number;
   q: string;
   a: string;
   b: string;

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -3,8 +3,6 @@
 export interface BalanceGameRoundResponse {
   totalRounds: number;
   currentRound: number;
-  startTime: string; // deprecated
-  endTime: string; // deprecated
   playSeconds: number;
   q: string;
   a: string;

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -3,6 +3,8 @@
 export interface BalanceGameRoundResponse {
   totalRounds: number;
   currentRound: number;
+  startTime: string; // deprecated
+  endTime: string; // deprecated
   playSeconds: number;
   q: string;
   a: string;


### PR DESCRIPTION
closes #191 
# 📝작업 내용
- 밸런스게임, QnA 게임에서 사용되는 타이머의 로직을 변경했습니다.
- startTime, endTime이 deprecated되고 playSeconds라는 새로운 데이터에 맞춰서 각 로컬 환경에서 타이머가 카운트됩니다.
- 추후에 카드 뒤집기 게임에서 사용될 타이머를 위해 useSSE 훅을 구현했습니다.
# 📷스크린샷(필요 시)

# ✨PR Point
- 더 개선할 점이 있다면 말씀해주세요!