### PR TITLE
UserInfoCard align 틀어지는 이슈 수정

### DIFF
--- a/src/components/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/UserInfoCard/UserInfoCard.tsx
@@ -49,7 +49,7 @@ const UserInfoCard = ({
           />
         </section>
       )}
-      <figure className="rounded-l-lg overflow-hidden w-[4rem] relative bg-white">
+      <figure className="flex justify-center items-center rounded-l-lg overflow-hidden w-[4rem] bg-white">
         <Image
           src={`/images/characters/${fileName}.webp`}
           alt="profile"

--- a/src/components/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/UserInfoCard/UserInfoCard.tsx
@@ -53,8 +53,8 @@ const UserInfoCard = ({
         <Image
           src={`/images/characters/${fileName}.webp`}
           alt="profile"
-          width={64}
-          height={64}
+          width={58}
+          height={58}
           priority
         />
         <figcaption className="sr-only">{`${fileName} 캐릭터 이미지`}</figcaption>

--- a/src/components/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/UserInfoCard/UserInfoCard.tsx
@@ -57,6 +57,7 @@ const UserInfoCard = ({
           height={64}
           priority
         />
+        <figcaption className="sr-only">{`${fileName} 캐릭터 이미지`}</figcaption>
       </figure>
       <div className="w-[calc(100%-4rem)] pl-4 pr-1 flex items-center font-bold justify-between gap-1">
         <span className={cn(myName === name && 'text-primary-400')}>


### PR DESCRIPTION
close #198 

# 📝작업 내용
유저 정보 카드에서 이미지 작게보이고 align 틀어지는 현상
- 상황 : 환경에 따라 이미지가 작게 렌더링 되는 경우 align이 상단 왼쪽으로 치우침
- 원인 : 이미지가 고정 크기를 가지기 때문에 부모 영역을 채우지 못해 치우침 발생
- 해결 : flex 적용하여 부모 영역을 채우고, 중앙 정렬하여 해결
* fill과 object-contain으로 해결할 수 있으나 성능 때문에 사용하지 않았습니다.

# 📷스크린샷
<img width="367" height="318" alt="image" src="https://github.com/user-attachments/assets/2cf4a6b9-61ab-4922-8c4a-2e0d699a52d3" />

# ✨PR Point
버그 재현 불가로 임의로 이미지를 작게 조정하여 해결했습니다.
align이 틀어지는 현상은 확실히 방지할 수 있습니다. 
_*이미지가 작게 보이는 부분은 어떤 테스트 환경인지 확인이 필요합니다._