### PR TITLE
긴 링크 채팅창 넘침 이슈 수정

### DIFF
--- a/src/components/Chatting/Item.tsx
+++ b/src/components/Chatting/Item.tsx
@@ -11,7 +11,7 @@ const Item = ({ sender, content, index, type }: ItemProps) => {
   return (
     <div
       className={cn(
-        'p-3 ',
+        'p-3',
         index === 0 && 'rounded-t-lg',
         type === 'system'
           ? 'bg-primary/20'
@@ -26,7 +26,7 @@ const Item = ({ sender, content, index, type }: ItemProps) => {
       ) : (
         <div>
           <span className="font-semibold">{sender}</span>
-          {`: `}
+          {` : `}
           <span className="break-words hyphens-auto">{content}</span>
         </div>
       )}

--- a/src/components/Chatting/Item.tsx
+++ b/src/components/Chatting/Item.tsx
@@ -22,12 +22,12 @@ const Item = ({ sender, content, index, type }: ItemProps) => {
       )}
     >
       {type == 'system' ? (
-        <span className="font-semibold">{content}</span>
+        <span className="font-semibold break-words">{content}</span>
       ) : (
         <div>
           <span className="font-semibold">{sender}</span>
           {`: `}
-          <span>{content}</span>
+          <span className="break-words hyphens-auto">{content}</span>
         </div>
       )}
     </div>


### PR DESCRIPTION
close #202 

# 📝작업 내용
긴 링크 채팅창 넘침 이슈를 수정합니다.
- 상황 : 긴 링크 채팅창 넘침
- 원인 : 줄바꿈 없는 텍스트의 경우, 한 줄로 출력되기 때문에 넘침
- 해결 : break-words를 추가했습니다.
*break-all은 영어 가독성이 떨어지기 때문에 제외했습니다.

# 🧪테스트
- 긴 링크
```
https://www.example.com/very/long/path/to/a/specific/page?parameter1=value1&parameter2=value2
```
- 한글
```
음식, 연애, 라이프스타일, 가치관까지! 다양한 주제의 밸런스 게임을 한 곳에서 즐길 수 있어요. "계란 프라이 반숙 vs 완숙", "장거리 연애 vs 매일 만나는 연애" 등 친구들과 함께 고민해보세요. 당신의 선택은?
```
- 영어
```
Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
```
- 긴 영어 단어 : hyphens-auto 적용 테스트
```
Officially recognized by the Duden dictionary as the longest word in German, Kraftfahrzeug­haftpflichtversicherung is a 36 letter word for motor vehicle liability insurance.
```

# 📷스크린샷
<img width="250" alt="image" src="https://github.com/user-attachments/assets/daeea0a4-2401-4463-93fc-37e7bdee661e" />

# ✨PR Point
리뷰 3초컷입니다!
텍스트 관련 디테일한 기술을 알고 있다면 공유해주세요! 추가 적용해보겠습니다~