### PR TITLE
최종결과 QA

### DIFF
--- a/src/components/FinalResultChart/ResultRow.tsx
+++ b/src/components/FinalResultChart/ResultRow.tsx
@@ -27,7 +27,14 @@ const ResultRow = ({ data }: ResultRowProps) => {
       <Tooltip>
         <TooltipTrigger asChild>
           <div className="w-full flex items-center justify-center gap-6">
-            <span className="w-[25%] text-right break-keep">{candidateA}</span>
+            <span
+              className={cn(
+                'w-[25%] text-right break-keep',
+                votesA > votesB && 'font-bold'
+              )}
+            >
+              {candidateA}
+            </span>
 
             {totalVotes === 0 ? (
               <div className="w-[50%] h-5 bg-container-100 rounded-full flex items-center justify-center">
@@ -69,7 +76,14 @@ const ResultRow = ({ data }: ResultRowProps) => {
               </div>
             )}
 
-            <span className="w-[25%] break-keep">{candidateB}</span>
+            <span
+              className={cn(
+                'w-[25%] break-keep',
+                votesB > votesA && 'font-bold'
+              )}
+            >
+              {candidateB}
+            </span>
           </div>
         </TooltipTrigger>
 

--- a/src/components/FinalResultChart/ResultRow.tsx
+++ b/src/components/FinalResultChart/ResultRow.tsx
@@ -37,10 +37,8 @@ const ResultRow = ({ data }: ResultRowProps) => {
             </span>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            <p className="text-left whitespace-pre-wrap">
-              {data.result.a.length > 0
-                ? data.result.a.join('\n')
-                : '투표자가 없어요!'}
+            <p className="text-right whitespace-pre-wrap">
+              {votesA > 0 ? data.result.a.join('\n') : '투표자가 없어요!'}
             </p>
           </TooltipContent>
         </Tooltip>
@@ -88,7 +86,7 @@ const ResultRow = ({ data }: ResultRowProps) => {
             )}
           </TooltipTrigger>
           <TooltipContent side="top">
-            <p className="max-w-[200px] text-center">{data.q}</p>
+            <p className="mtext-center">{data.q}</p>
           </TooltipContent>
         </Tooltip>
 
@@ -104,10 +102,8 @@ const ResultRow = ({ data }: ResultRowProps) => {
             </span>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            <p className="max-w-[200px] text-left whitespace-pre-wrap">
-              {data.result.b.length > 0
-                ? data.result.b.join('\n')
-                : '투표자가 없어요!'}
+            <p className="whitespace-pre-wrap">
+              {votesB > 0 ? data.result.b.join('\n') : '투표자가 없어요!'}
             </p>
           </TooltipContent>
         </Tooltip>

--- a/src/components/FinalResultChart/ResultRow.tsx
+++ b/src/components/FinalResultChart/ResultRow.tsx
@@ -23,10 +23,10 @@ const ResultRow = ({ data }: ResultRowProps) => {
   const percentageCandidateB = totalVotes > 0 ? (votesB / totalVotes) * 100 : 0;
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="w-full flex items-center justify-center gap-6">
+    <TooltipProvider delayDuration={0}>
+      <div className="w-full flex items-center justify-center gap-6">
+        <Tooltip>
+          <TooltipTrigger asChild>
             <span
               className={cn(
                 'w-[25%] text-right break-keep',
@@ -35,7 +35,18 @@ const ResultRow = ({ data }: ResultRowProps) => {
             >
               {candidateA}
             </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p className="text-left whitespace-pre-wrap">
+              {data.result.a.length > 0
+                ? data.result.a.join('\n')
+                : '투표자가 없어요!'}
+            </p>
+          </TooltipContent>
+        </Tooltip>
 
+        <Tooltip>
+          <TooltipTrigger asChild>
             {totalVotes === 0 ? (
               <div className="w-[50%] h-5 bg-container-100 rounded-full flex items-center justify-center">
                 <span className="font-bold text-sm text-purple text-center w-full">
@@ -75,7 +86,14 @@ const ResultRow = ({ data }: ResultRowProps) => {
                 )}
               </div>
             )}
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            <p className="max-w-[200px] text-center">{data.q}</p>
+          </TooltipContent>
+        </Tooltip>
 
+        <Tooltip>
+          <TooltipTrigger asChild>
             <span
               className={cn(
                 'w-[25%] break-keep',
@@ -84,13 +102,16 @@ const ResultRow = ({ data }: ResultRowProps) => {
             >
               {candidateB}
             </span>
-          </div>
-        </TooltipTrigger>
-
-        <TooltipContent side="top">
-          <p className="max-w-[200px] text-center">{data.q}</p>
-        </TooltipContent>
-      </Tooltip>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p className="max-w-[200px] text-left whitespace-pre-wrap">
+              {data.result.b.length > 0
+                ? data.result.b.join('\n')
+                : '투표자가 없어요!'}
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
     </TooltipProvider>
   );
 };


### PR DESCRIPTION
# 📝작업 내용
- 득표수 더 많은 후보자는 font bold 처리하여 가독성 개선
- 답변(후보) hover 시 툴팁에 투표자 목록 나오도록 구현
# 📷스크린샷(필요 시)

<img width="1620" height="1176" alt="image" src="https://github.com/user-attachments/assets/7cc82082-5b87-42f3-bed5-567486784163" />
- 득표수가 더 많은 경우 bold 처리 되었습니다.
- 둘다 0표거나 무승부인 경우는 별도의 처리가 되지 않습니다.

https://github.com/user-attachments/assets/f5a3d219-6e17-47ec-8fe7-beb4f80b4bef
- 기존 질문 툴팁의 경우 가운데 Bar로 trigger 구역을 축소했습니다.
- 툴팁 delay를 0으로 설정하여 바로 툴팁이 뜨도록 변경했습니다.

# ✨PR Point
- 현재 질문은 위로, 투표자 목록은 아래로 뜨게 했는데, 둘다 아래로 뜨게 하는게 좋을까요? 아니면 지금 방식이 괜찮은가요?
- 더 개선해야할 점이 있다면 말씀해주세요!