### PR TITLE
레이아웃 광고 영역 추가

### DIFF
--- a/src/app/room/[roomId]/_component/PrevGame.tsx
+++ b/src/app/room/[roomId]/_component/PrevGame.tsx
@@ -95,7 +95,7 @@ const PrevGame = ({
   };
 
   return (
-    <section className="w-full h-full flex flex-col justify-center items-center gap-7 px-900">
+    <section className="bg-container/60 h-full flex flex-col justify-center items-center gap-7 px-900 rounded-lg">
       <span className="font-semibold">잠시 후 게임이 시작됩니다.</span>
       <GameListCard
         title={roomDetail.game.nameKr}
@@ -103,7 +103,6 @@ const PrevGame = ({
         src={roomDetail.game.thumbnailUrl}
         className="h-16 pointer-events-none"
       />
-
       <section className="flex flex-col gap-2 w-full items-center">
         {isRoomManager && (
           <>

--- a/src/app/room/[roomId]/_component/PrevGame.tsx
+++ b/src/app/room/[roomId]/_component/PrevGame.tsx
@@ -95,7 +95,7 @@ const PrevGame = ({
   };
 
   return (
-    <section className="bg-container/60 h-full flex flex-col justify-center items-center gap-7 px-900 rounded-lg">
+    <section className="bg-container/60 h-full flex flex-col justify-center items-center gap-7 p-800 rounded-lg">
       <span className="font-semibold">잠시 후 게임이 시작됩니다.</span>
       <GameListCard
         title={roomDetail.game.nameKr}

--- a/src/app/room/[roomId]/_component/UserList.tsx
+++ b/src/app/room/[roomId]/_component/UserList.tsx
@@ -26,7 +26,7 @@ const UserList = ({ players }: UserListProps) => {
   };
 
   return (
-    <section className="flex flex-col gap-3 h-[80vh] w-1/6 min-w-[15rem] max-w-[20rem] relative ml-10">
+    <section className="flex flex-col gap-3 h-[80vh] w-[14rem] max-w-[15rem] relative ml-10">
       {roomStatus === ROOM_STATUS.IDLE && (
         <Button
           className="absolute -top-12 left-0"

--- a/src/app/room/[roomId]/_component/UserList.tsx
+++ b/src/app/room/[roomId]/_component/UserList.tsx
@@ -26,7 +26,7 @@ const UserList = ({ players }: UserListProps) => {
   };
 
   return (
-    <section className="flex flex-col gap-3 h-[80vh] w-[14rem] max-w-[15rem] relative ml-10">
+    <section className="flex flex-col gap-3 h-[80vh] w-[14rem] min-w-[14rem] max-w-[15rem] relative ml-10">
       {roomStatus === ROOM_STATUS.IDLE && (
         <Button
           className="absolute -top-12 left-0"

--- a/src/app/room/[roomId]/_component/WaitingRoom.tsx
+++ b/src/app/room/[roomId]/_component/WaitingRoom.tsx
@@ -135,7 +135,7 @@ const WaitingRoom = ({
   }
 
   return (
-    <section className="w-screen min-h-screen flex items-start gap-4 shrink-0 py-20">
+    <section className="w-screen min-h-screen flex items-start gap-4 shrink-0 py-20 2xl:justify-center">
       <UserList players={players} />
       <section className="flex flex-col gap-300 h-[calc(100vh-12rem)] min-h-[30rem] min-w-max max-w-[70rem] w-full rounded-lg">
         <ErrorHandlingWrapper

--- a/src/app/room/[roomId]/_component/WaitingRoom.tsx
+++ b/src/app/room/[roomId]/_component/WaitingRoom.tsx
@@ -5,7 +5,7 @@ import * as StompJS from '@stomp/stompjs';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
-import { Chatting, Spinner } from '@/components';
+import { AdBanner, Chatting, Spinner } from '@/components';
 import ErrorFallback from '@/components/ErrorBoundary/ErrorFallback';
 import ErrorHandlingWrapper from '@/components/ErrorBoundary/ErrorHandlingWrapper';
 import { GAME_TYPES } from '@/constants/form';
@@ -152,13 +152,7 @@ const WaitingRoom = ({
           />
         </ErrorHandlingWrapper>
         {isDevelopment && (
-          <aside
-            className="ad-slot self-center text-center bg-black w-ads-leaderboard-wide h-ads-leaderboard rounded shrink-0"
-            aria-label="광고 영역"
-          >
-            {/* TODO: 광고 붙이기 */}
-            와이드 리더보드 광고 영역
-          </aside>
+          <AdBanner type="wideLeaderboard">와이드 리더보드 광고 영역</AdBanner>
         )}
       </section>
 

--- a/src/app/room/[roomId]/_component/WaitingRoom.tsx
+++ b/src/app/room/[roomId]/_component/WaitingRoom.tsx
@@ -17,6 +17,7 @@ import { EnterRoomProps } from '@/hooks/useWebSocket';
 import useRoomStore from '@/store/useRoomStore';
 import { ChatMessage } from '@/types';
 import { Player } from '@/types/api';
+import { isDevelopment } from '@/utils/env';
 import { gameToType } from '@/utils/form';
 
 import GamePanel from './GamePanel';
@@ -134,10 +135,9 @@ const WaitingRoom = ({
   }
 
   return (
-    <section className="w-screen min-h-screen flex items-center gap-10 shrink-0 py-500">
+    <section className="w-screen min-h-screen flex items-start gap-4 shrink-0 py-20">
       <UserList players={players} />
-
-      <section className="h-[80vh] min-h-[30rem] min-w-max max-w-[70rem] w-full bg-container/50 rounded-lg">
+      <section className="flex flex-col gap-300 h-[calc(100vh-12rem)] min-h-[30rem] min-w-max max-w-[70rem] w-full rounded-lg">
         <ErrorHandlingWrapper
           fallbackComponent={ErrorFallback}
           suspenseFallback={<Spinner />}
@@ -151,9 +151,18 @@ const WaitingRoom = ({
             sendMessage={sendMessage}
           />
         </ErrorHandlingWrapper>
+        {isDevelopment && (
+          <aside
+            className="ad-slot self-center text-center bg-black w-ads-leaderboard-wide h-ads-leaderboard rounded shrink-0"
+            aria-label="광고 영역"
+          >
+            {/* TODO: 광고 붙이기 */}
+            와이드 리더보드 광고 영역
+          </aside>
+        )}
       </section>
 
-      <section className="flex flex-col h-[80vh] min-h-[30rem] w-[25vw] min-w-[18rem] max-w-[23rem] pr-10 gap-2">
+      <section className="flex flex-col h-[calc(100vh-12rem)] min-h-[30rem] w-[25vw] min-w-[18rem] max-w-[23rem] pr-10 gap-2">
         <Chatting
           myName={myName}
           chatMessages={chatMessages}

--- a/src/app/room/[roomId]/_component/WaitingRoom.tsx
+++ b/src/app/room/[roomId]/_component/WaitingRoom.tsx
@@ -162,7 +162,7 @@ const WaitingRoom = ({
         )}
       </section>
 
-      <section className="flex flex-col h-[calc(100vh-12rem)] min-h-[30rem] w-[25vw] min-w-[18rem] max-w-[23rem] pr-10 gap-2">
+      <section className="flex flex-col h-[calc(100vh-12rem)] min-h-[30rem] w-[25vw] min-w-[17rem] max-w-[18rem] pr-9 gap-2">
         <Chatting
           myName={myName}
           chatMessages={chatMessages}

--- a/src/components/AdBanner/AdBanner.tsx
+++ b/src/components/AdBanner/AdBanner.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+type AdType = 'leaderboard' | 'wideLeaderboard';
+
+interface AdBannerProps extends React.HTMLAttributes<HTMLDivElement> {
+  type: AdType;
+  ariaLabel?: string;
+}
+
+// TODO: 광고 붙이기
+const AdBanner = ({
+  type,
+  ariaLabel = '광고 영역',
+  children,
+  ...props
+}: AdBannerProps) => {
+  const adStyle = {
+    leaderboard: 'w-ads-leaderboard h-ads-leaderboard',
+    wideLeaderboard: 'w-ads-leaderboard-wide h-ads-leaderboard',
+  };
+  return (
+    <aside
+      className={cn(
+        'ad-slot text-center bg-black rounded shrink-0',
+        adStyle[type]
+      )}
+      aria-label={ariaLabel}
+      {...props}
+    >
+      {children}
+    </aside>
+  );
+};
+
+export default AdBanner;

--- a/src/components/AdBanner/AdBanner.tsx
+++ b/src/components/AdBanner/AdBanner.tsx
@@ -21,7 +21,7 @@ const AdBanner = ({
     wideLeaderboard: 'w-ads-leaderboard-wide h-ads-leaderboard',
   };
   return (
-    <aside
+    <div
       className={cn(
         'ad-slot text-center bg-black rounded shrink-0',
         adStyle[type]
@@ -30,7 +30,7 @@ const AdBanner = ({
       {...props}
     >
       {children}
-    </aside>
+    </div>
   );
 };
 

--- a/src/components/AdBanner/index.ts
+++ b/src/components/AdBanner/index.ts
@@ -1,0 +1,1 @@
+export { default as AdBanner } from './AdBanner';

--- a/src/components/BalanceGame/BalanceGameControl.tsx
+++ b/src/components/BalanceGame/BalanceGameControl.tsx
@@ -38,6 +38,7 @@ const BalanceGameControl = ({
     <>
       {roomStatus === ROOM_STATUS.RESULT && isRoomManager && (
         <Button
+          size="md"
           className="w-full"
           onClick={handleEnterNextRound}
         >
@@ -48,6 +49,7 @@ const BalanceGameControl = ({
       )}
       {roomStatus === ROOM_STATUS.FINAL_RESULT && isRoomManager && (
         <Button
+          size="md"
           className="w-full"
           onClick={handleMoveToWaitingRoom}
         >

--- a/src/components/BalanceGame/BalanceGameProgress.tsx
+++ b/src/components/BalanceGame/BalanceGameProgress.tsx
@@ -38,7 +38,7 @@ const BalanceGameProgress = ({
   };
 
   return (
-    <main className="flex flex-col items-center justify-center p-8 h-full">
+    <main className="bg-container/60 flex flex-col items-center justify-center p-8 h-full rounded-lg">
       <section className="w-full mb-4 flex flex-col items-center gap-4">
         <Timer
           playSeconds={round.playSeconds}

--- a/src/components/Chatting/Chatting.tsx
+++ b/src/components/Chatting/Chatting.tsx
@@ -45,8 +45,8 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
   }, [chatMessages]);
 
   return (
-    <section className="h-[calc(100%-3rem)]">
-      <section className="h-[calc(100%-4rem)] bg-container-600 rounded-t-lg overflow-auto">
+    <section className="h-full">
+      <section className="h-[calc(100%-4.5rem)] bg-container-600 rounded-t-lg overflow-auto">
         {chatMessages.map((item, index) => (
           <Item
             key={index}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 const Footer = () => {
   return (
-    <footer className="text-gray-300 text-center text-body3 py-2 mb-400">
+    <footer className="flex justify-center items-center text-gray-300 text-center text-body3 h-20">
       <div className="space-y-1">
         <div>© 2024-2025 Team grouphi. All Rights Reserved.</div>
         <div>

--- a/src/components/HomeClient/HomeClient.tsx
+++ b/src/components/HomeClient/HomeClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 
-import GameListCarousel, { Footer, MainHeader } from '@/components';
+import GameListCarousel, { AdBanner, Footer, MainHeader } from '@/components';
 import useGameStore from '@/store/useGameStore';
 import useRoomStore from '@/store/useRoomStore';
 import { GameResponse } from '@/types/api';
@@ -47,13 +47,7 @@ const HomeClient = ({ games }: HomeClientProps) => {
           </section>
         )}
         {isDevelopment && (
-          <aside
-            className="ad-slot text-center bg-black w-ads-leaderboard-wide h-ads-leaderboard rounded shrink-0"
-            aria-label="광고 영역"
-          >
-            {/* TODO: 광고 붙이기 */}
-            와이드 리더보드 광고 영역
-          </aside>
+          <AdBanner type="wideLeaderboard">와이드 리더보드 광고 영역</AdBanner>
         )}
       </main>
       <Footer />

--- a/src/components/HomeClient/HomeClient.tsx
+++ b/src/components/HomeClient/HomeClient.tsx
@@ -45,6 +45,12 @@ const HomeClient = ({ games }: HomeClientProps) => {
             <span>게임 준비중입니다</span>
           </section>
         )}
+        <aside
+          className="ad-slot text-center bg-gray-800 h-28 invisible"
+          aria-label="광고 영역"
+        >
+          {/* TODO: 광고 붙이기 */}
+        </aside>
       </main>
       <Footer />
     </div>

--- a/src/components/HomeClient/HomeClient.tsx
+++ b/src/components/HomeClient/HomeClient.tsx
@@ -30,18 +30,16 @@ const HomeClient = ({ games }: HomeClientProps) => {
   return (
     <div className="flex flex-col min-h-screen justify-between">
       <MainHeader />
-      <main className="px-800 mb-800">
+      <main className="px-800">
         {games.length > 0 ? (
-          <>
-            <section
-              id="gamelist"
-              className="flex flex-col grow items-center"
-            >
-              <span className="text-lg">Game List</span>
-              <span className="text-md pb-300">▽</span>
-              <GameListCarousel games={games} />
-            </section>
-          </>
+          <section
+            id="gamelist"
+            className="my-600 flex flex-col grow items-center"
+          >
+            <span className="text-lg">Game List</span>
+            <span className="text-md pb-300">▽</span>
+            <GameListCarousel games={games} />
+          </section>
         ) : (
           <section className="flex h-full justify-center items-center">
             <span>게임 준비중입니다</span>

--- a/src/components/HomeClient/HomeClient.tsx
+++ b/src/components/HomeClient/HomeClient.tsx
@@ -6,6 +6,7 @@ import GameListCarousel, { Footer, MainHeader } from '@/components';
 import useGameStore from '@/store/useGameStore';
 import useRoomStore from '@/store/useRoomStore';
 import { GameResponse } from '@/types/api';
+import { isDevelopment } from '@/utils/env';
 
 interface HomeClientProps {
   games: GameResponse[];
@@ -30,7 +31,7 @@ const HomeClient = ({ games }: HomeClientProps) => {
   return (
     <div className="flex flex-col min-h-screen justify-between">
       <MainHeader />
-      <main className="px-800">
+      <main className="flex flex-col items-center px-800">
         {games.length > 0 ? (
           <section
             id="gamelist"
@@ -45,12 +46,15 @@ const HomeClient = ({ games }: HomeClientProps) => {
             <span>게임 준비중입니다</span>
           </section>
         )}
-        <aside
-          className="ad-slot text-center bg-gray-800 h-28 invisible"
-          aria-label="광고 영역"
-        >
-          {/* TODO: 광고 붙이기 */}
-        </aside>
+        {isDevelopment && (
+          <aside
+            className="ad-slot text-center bg-black w-ads-leaderboard-wide h-ads-leaderboard rounded shrink-0"
+            aria-label="광고 영역"
+          >
+            {/* TODO: 광고 붙이기 */}
+            와이드 리더보드 광고 영역
+          </aside>
+        )}
       </main>
       <Footer />
     </div>

--- a/src/components/MainHeader/MainHeader.tsx
+++ b/src/components/MainHeader/MainHeader.tsx
@@ -28,7 +28,7 @@ const MainHeader = () => {
   ];
 
   return (
-    <header className="flex justify-between items-center h-24 px-800">
+    <header className="flex justify-between items-end h-20 px-800">
       <Logo onClick={() => router.push(PATH.HOME)} />
       <div className="flex">
         <NicknameBar

--- a/src/components/MainHeader/MainHeader.tsx
+++ b/src/components/MainHeader/MainHeader.tsx
@@ -28,7 +28,7 @@ const MainHeader = () => {
   ];
 
   return (
-    <header className="flex justify-between p-800 pb-0 mb-800">
+    <header className="flex justify-between items-center h-24 px-800">
       <Logo onClick={() => router.push(PATH.HOME)} />
       <div className="flex">
         <NicknameBar

--- a/src/components/PartialResultChart/PartialResultChart.tsx
+++ b/src/components/PartialResultChart/PartialResultChart.tsx
@@ -23,7 +23,7 @@ const PartialResultChart = ({ data }: PartialResultChartProps) => {
   const { round } = useBalanceGameStore();
 
   return (
-    <section className="bg-container-600 h-full w-full min-h-fit border-white/50 flex flex-col justify-between items-center rounded-lg gap-8 p-8">
+    <section className="bg-container-600 h-full w-full min-h-fit border-white/50 flex flex-col justify-between items-center rounded-lg gap-8 p-5">
       <section>
         <h1 className="pt-600 text-title1 font-semibold">
           {partialData.round}라운드 결과
@@ -49,7 +49,7 @@ const PartialResultChart = ({ data }: PartialResultChartProps) => {
         <UserList
           title={UNSELECTED}
           data={partialData.result.c.join(', ')}
-          className="selected-c w-full bg-container-700/70"
+          className="selected-c w-[50%] bg-container-700/70"
         />
       )}
       <section className="self-end">

--- a/src/components/PieChart/PieChart.tsx
+++ b/src/components/PieChart/PieChart.tsx
@@ -7,7 +7,7 @@ import {
   Legend,
   Tooltip,
 } from 'chart.js';
-import React, { HTMLAttributes } from 'react';
+import { HTMLAttributes } from 'react';
 import { Doughnut } from 'react-chartjs-2';
 
 import { cn } from '@/lib/utils';
@@ -29,7 +29,7 @@ const PieChart = ({
   className,
   ...props
 }: PieChartProps) => {
-  const defaultClassName = 'w-96';
+  const defaultClassName = 'w-72';
   const combinedClassName = className
     ? cn(defaultClassName, className)
     : defaultClassName;
@@ -73,7 +73,7 @@ const PieChart = ({
 
   if (data.length === 0) {
     return (
-      <section className="min-w-96 flex justify-center items-center rounded bg-black/50">
+      <section className="min-w-72 flex justify-center items-center rounded bg-black/50">
         데이터가 없습니다
       </section>
     );

--- a/src/components/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/UserInfoCard/UserInfoCard.tsx
@@ -59,8 +59,8 @@ const UserInfoCard = ({
         />
         <figcaption className="sr-only">{`${fileName} 캐릭터 이미지`}</figcaption>
       </figure>
-      <div className="w-[calc(100%-4rem)] pl-4 pr-1 flex items-center font-bold justify-between gap-1">
-        <span className={cn(myName === name && 'text-primary-400')}>
+      <div className="w-[calc(100%-4rem)] pl-3 pr-2 flex items-center font-medium justify-between gap-1">
+        <span className={cn(myName === name && 'text-primary-400 font-bold')}>
           {name}
         </span>
         {name === myName && !isReady && (

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export { AdBanner } from './AdBanner';
 export {
   BalanceGameControl,
   BalanceGameProgress,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -71,6 +71,8 @@ const config: Config = {
         'icon-sm': '1rem',
         'icon-md': '1.5rem',
         'icon-lg': '2.25rem',
+        'ads-leaderboard': '45.5rem', // 728px
+        'ads-leaderboard-wide': '60.625rem', // 970px
       },
       height: {
         sm: '2rem',
@@ -81,6 +83,7 @@ const config: Config = {
         'icon-sm': '1rem',
         'icon-md': '1.5rem',
         'icon-lg': '2.25rem',
+        'ads-leaderboard': '5.625rem', // 90px
       },
       spacing: {
         '50': '0.125rem', // 2px


### PR DESCRIPTION
close #217 

# 📝작업 내용
구글 애드센스 도입에 따라 레이아웃에 광고 영역을 추가합니다.
광고 영역 추가에 따라 기존 UI 크기도 작게 조정했습니다.
- 홈페이지 하단 광고 1개 추가
- 룸페이지(대기/부분결과/최종결과) 하단 광고 1개 추가


**참고) 구글 애드센스 리더보드**
[구글 애드센스](https://support.google.com/admanager/answer/1100453?hl=ko)를 참고하여 현재 웹사이트 영역에 맞는 두 가지 크기를 고려했습니다.
리더보드는 '웹페이지 상/하단 가로형 광고'로 많이 사용됩니다.

- 리더보드 728x90 : 실적이 우수한 광고 크기로 텍스트와 이미지 광고를 모두 사용할 수 있습니다.
- 와이드 리더보드 970x90 또는 970x250 : 큰 리더보드로 동영상, 사진, 애플리케이션 등 고화질 콘텐츠를 제공할 수 있습니다.

# 📷스크린샷
### 홈페이지
**AS-IS**
<img alt="image" src="https://github.com/user-attachments/assets/8a04d7b6-7596-4cc2-b8ff-5c5a829b3905" />
**TO-BE**
<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/e26741c9-b965-4c7a-ad35-8fac8bec58a7" />

###룸페이지
**AS-IS**
<img alt="image" src="https://github.com/user-attachments/assets/6f220cd3-2e9e-45fb-99aa-b651d06b9497" />
**TO-BE**
<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/35480824-9ede-4022-b73d-b3931882cacb" />

# ✨PR Point
- 회의에서 논의한 대로 하단 광고 2개의 광고를 추가한 뒤 추이를 보고 사이드 광고 등을 추가할 예정입니다.
- 리더보드, 와이드 리더보드 중 어떤 광고 크기를 채택할지 고민입니다! 현재 PR에서는 최대 크기로 와이드 리더보드를 적용했습니다.
- 보기에 어색한 부분, 개선할 점이 있다면 알려주세요!✋
- highPriority 반영 완료