### PR TITLE
메인, 대기실 페이지 스크롤 대응과 반응형 UI 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,16 @@ body {
   --color-scroll-track: #352778;
   --color-scroll-thumb: #cab8de;
 
-  font-family: Arial, Helvetica, sans-serif;
+  font-family:
+    var(--font-pretendard),
+    var(--font-noto-sans),
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    sans-serif;
 }
 
 ::-webkit-scrollbar {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  font-size: 16px;
+}
+
 body {
   --color-scroll-track: #352778;
   --color-scroll-thumb: #cab8de;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`font-sans antialiased text-base text relative min-h-screen bg-gradient-purple`}
+        className={`font-sans antialiased text-sm 2xl:text-base text relative min-h-screen bg-gradient-purple`}
       >
         {GA4_ID && process.env.NODE_ENV === 'production' && (
           <>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 
+import { Viewport } from 'next';
 import Script from 'next/script';
 import React from 'react';
 
@@ -16,6 +17,11 @@ import Providers from '@/utils/providers';
 import { notoSans, pretendard } from './fonts/fonts';
 
 export const metadata = METADATA;
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
 
 export default function RootLayout({
   children,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,10 @@ export default function RootLayout({
 }>) {
   const GA4_ID = process.env.NEXT_PUBLIC_GA4_ID;
   return (
-    <html lang="ko">
+    <html
+      lang="ko"
+      className={`${pretendard.variable} ${notoSans.variable}`}
+    >
       <head>
         <link
           rel="shortcut icon"
@@ -48,7 +51,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${pretendard.variable} ${notoSans.variable} font-sans antialiased text relative min-h-screen bg-gradient-purple`}
+        className={`font-sans antialiased text-base text relative min-h-screen bg-gradient-purple`}
       >
         {GA4_ID && process.env.NODE_ENV === 'production' && (
           <>

--- a/src/app/room/[roomId]/_component/PrevGame.tsx
+++ b/src/app/room/[roomId]/_component/PrevGame.tsx
@@ -101,7 +101,7 @@ const PrevGame = ({
         title={roomDetail.game.nameKr}
         description={roomDetail.game.descriptionKr}
         src={roomDetail.game.thumbnailUrl}
-        className="h-16 pointer-events-none"
+        className="min-w-80 max-w-80 2xl:max-w-96 pointer-events-none"
       />
       <section className="flex flex-col gap-2 w-full items-center">
         {isRoomManager && (

--- a/src/app/room/[roomId]/_component/TotalRoundsForm.tsx
+++ b/src/app/room/[roomId]/_component/TotalRoundsForm.tsx
@@ -63,7 +63,7 @@ const TotalRoundsForm = ({
                 <FormControl>
                   <section className="flex gap-500 items-center min-h-9">
                     <Label
-                      className="w-24"
+                      className="min-w-fit"
                       htmlFor="total-rounds"
                     >
                       질문의 개수

--- a/src/app/room/[roomId]/_component/WaitingRoom.tsx
+++ b/src/app/room/[roomId]/_component/WaitingRoom.tsx
@@ -138,7 +138,7 @@ const WaitingRoom = ({
   return (
     <section className="w-screen min-h-screen flex items-start justify-start 2xl:justify-center gap-4 shrink-0 py-20 overflow-y-hidden">
       <UserList players={players} />
-      <section className="flex flex-col gap-300 h-[calc(100vh-12rem)] min-h-[30rem] max-w-[60%] min-w-[22.5rem] w-full rounded-lg">
+      <section className="flex flex-col gap-300 h-[calc(100vh-12rem)] min-h-[30rem] max-w-[60%] min-w-max w-full rounded-lg shrink-0">
         <ErrorHandlingWrapper
           fallbackComponent={ErrorFallback}
           suspenseFallback={<Spinner />}
@@ -162,7 +162,7 @@ const WaitingRoom = ({
         )}
       </section>
 
-      <section className="flex flex-col h-[calc(100vh-12rem)] min-h-[30rem] w-[25vw] min-w-[17rem] max-w-[18rem] pr-9 gap-2">
+      <section className="flex flex-col h-[calc(100vh-12rem)] min-h-[30rem] w-[25vw] min-w-[16rem] max-w-[18rem] pr-9 gap-2">
         <Chatting
           myName={myName}
           chatMessages={chatMessages}

--- a/src/app/room/[roomId]/_component/WaitingRoom.tsx
+++ b/src/app/room/[roomId]/_component/WaitingRoom.tsx
@@ -153,7 +153,12 @@ const WaitingRoom = ({
           />
         </ErrorHandlingWrapper>
         {isDevelopment && (
-          <AdBanner type="wideLeaderboard">와이드 리더보드 광고 영역</AdBanner>
+          <AdBanner
+            type="leaderboard"
+            className="w-full"
+          >
+            리더보드 광고 영역
+          </AdBanner>
         )}
       </section>
 

--- a/src/app/room/[roomId]/_component/WaitingRoom.tsx
+++ b/src/app/room/[roomId]/_component/WaitingRoom.tsx
@@ -23,6 +23,7 @@ import { gameToType } from '@/utils/form';
 import GamePanel from './GamePanel';
 import RoomControl from './RoomControl';
 import UserList from './UserList';
+
 interface WaitingRoomProps {
   connect: (params: EnterRoomProps) => void;
   chatMessages: ChatMessage[];
@@ -135,9 +136,9 @@ const WaitingRoom = ({
   }
 
   return (
-    <section className="w-screen min-h-screen flex items-start gap-4 shrink-0 py-20 2xl:justify-center">
+    <section className="w-screen min-h-screen flex items-start justify-start 2xl:justify-center gap-4 shrink-0 py-20 overflow-y-hidden">
       <UserList players={players} />
-      <section className="flex flex-col gap-300 h-[calc(100vh-12rem)] min-h-[30rem] min-w-max max-w-[70rem] w-full rounded-lg">
+      <section className="flex flex-col gap-300 h-[calc(100vh-12rem)] min-h-[30rem] max-w-[60%] min-w-[22.5rem] w-full rounded-lg">
         <ErrorHandlingWrapper
           fallbackComponent={ErrorFallback}
           suspenseFallback={<Spinner />}

--- a/src/components/AdBanner/AdBanner.tsx
+++ b/src/components/AdBanner/AdBanner.tsx
@@ -22,12 +22,13 @@ const AdBanner = ({
   };
   return (
     <div
+      {...props}
       className={cn(
         'ad-slot text-center bg-black rounded shrink-0',
-        adStyle[type]
+        adStyle[type],
+        props.className
       )}
       aria-label={ariaLabel}
-      {...props}
     >
       {children}
     </div>

--- a/src/components/FinalResultChart/ResultRow.tsx
+++ b/src/components/FinalResultChart/ResultRow.tsx
@@ -31,7 +31,7 @@ const ResultRow = ({ data }: ResultRowProps) => {
 
             {totalVotes === 0 ? (
               <div className="w-[50%] h-5 bg-container-100 rounded-full flex items-center justify-center">
-                <span className="font-bold text-sm text-purple text-center w-full">
+                <span className="font-bold text-sm text-purple text-center w-full min-w-28">
                   0
                 </span>
               </div>
@@ -46,7 +46,7 @@ const ResultRow = ({ data }: ResultRowProps) => {
                     )}
                     style={{ width: `${percentageCandidateA}%` }}
                   >
-                    <span className="font-bold text-sm text-purple text-center w-full">
+                    <span className="font-bold text-sm text-purple text-center w-full min-w-28">
                       {votesA}
                     </span>
                   </div>
@@ -61,7 +61,7 @@ const ResultRow = ({ data }: ResultRowProps) => {
                     )}
                     style={{ width: `${percentageCandidateB}%` }}
                   >
-                    <span className="font-bold text-sm text-purple text-center w-full">
+                    <span className="font-bold text-sm text-purple text-center w-full min-w-28">
                       {votesB}
                     </span>
                   </div>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 const Footer = () => {
   return (
-    <footer className="flex justify-center items-center text-gray-300 text-center text-body3 h-20">
+    <footer className="flex justify-center items-center text-gray-300 text-center text-body3 h-footer">
       <div className="space-y-1">
         <div>© 2024-2025 Team grouphi. All Rights Reserved.</div>
         <div>

--- a/src/components/GameListCard/GameListCard.tsx
+++ b/src/components/GameListCard/GameListCard.tsx
@@ -26,18 +26,12 @@ const GameListCard = ({
   const pathname = usePathname();
 
   const containerDefaultClassName =
-    'basis-1/3 max-w-64 2xl:max-w-80 min-w-48 2xl:min-w-60 aspect-[3/2] relative bg-primary-container shadow rounded-md overflow-hidden';
-  const containerClassName =
-    pathname === PATH.HOME
-      ? containerDefaultClassName
-      : cn(containerDefaultClassName, 'max-w-md min-w-80');
+    'basis-1/3 min-w-48 max-w-64 2xl:min-w-72 2xl:max-w-80 min-h-fit aspect-[3/2] relative bg-primary-container shadow rounded-md overflow-hidden';
 
   return (
     <article
       data-testid="gamelistcard-container"
-      className={
-        className ? cn(containerClassName, className) : containerClassName
-      }
+      className={cn(containerDefaultClassName, className)}
       {...props}
     >
       {src && (

--- a/src/components/GameListCard/GameListCard.tsx
+++ b/src/components/GameListCard/GameListCard.tsx
@@ -26,7 +26,7 @@ const GameListCard = ({
   const pathname = usePathname();
 
   const containerDefaultClassName =
-    'basis-1/3 max-w-80 min-w-60 h-full min-h-52 relative bg-primary-container shadow rounded-md overflow-hidden';
+    'basis-1/3 max-w-64 2xl:max-w-80 min-w-48 2xl:min-w-60 aspect-[3/2] relative bg-primary-container shadow rounded-md overflow-hidden';
   const containerClassName =
     pathname === PATH.HOME
       ? containerDefaultClassName
@@ -54,7 +54,7 @@ const GameListCard = ({
         onMouseEnter={() => setIsHover(true)}
         onMouseLeave={() => setIsHover(false)}
       >
-        <p className="text font-semibold truncate pb-400">{title}</p>
+        <p className="text-light font-semibold truncate pb-400">{title}</p>
         {isHover ? (
           <Button className="mt-50 hover:bg-primary">
             {pathname === PATH.HOME ? (

--- a/src/components/GameListCarousel/GameListCarousel.tsx
+++ b/src/components/GameListCarousel/GameListCarousel.tsx
@@ -76,7 +76,7 @@ const GameListCarousel = ({ games }: GameListCarouselProps) => {
       >
         <CarouselContent
           className={cn(
-            'grid grid-rows-2 grid-cols-3 gap-y-4 mb-500 min-w-[55rem]',
+            'grid grid-rows-2 grid-cols-3 gap-y-4 mb-400 min-w-max',
             path !== PATH.HOME && 'grid-cols-2'
           )}
         >

--- a/src/components/HomeClient/HomeClient.tsx
+++ b/src/components/HomeClient/HomeClient.tsx
@@ -29,9 +29,9 @@ const HomeClient = ({ games }: HomeClientProps) => {
   }, [setGames, games]);
 
   return (
-    <div className="flex flex-col min-h-screen justify-between">
+    <div className="flex flex-col min-h-screen justify-between overflow-y-hidden">
       <MainHeader />
-      <main className="flex flex-col items-center px-800">
+      <main className="flex flex-col items-center px-800 min-h-[calc(100%-10rem)]">
         {games.length > 0 ? (
           <section
             id="gamelist"

--- a/src/components/HomeClient/HomeClient.tsx
+++ b/src/components/HomeClient/HomeClient.tsx
@@ -37,7 +37,7 @@ const HomeClient = ({ games }: HomeClientProps) => {
             id="gamelist"
             className="my-600 flex flex-col grow items-center"
           >
-            <span className="text-lg">Game List</span>
+            <span className="text-md 2xl:text-lg">Game List</span>
             <span className="text-md pb-300">▽</span>
             <GameListCarousel games={games} />
           </section>

--- a/src/components/MainHeader/MainHeader.tsx
+++ b/src/components/MainHeader/MainHeader.tsx
@@ -30,7 +30,7 @@ const MainHeader = () => {
   return (
     <header className="flex justify-between items-end h-20 px-800">
       <Logo onClick={() => router.push(PATH.HOME)} />
-      <div className="flex">
+      <div className="flex items-center pl-4">
         <NicknameBar
           nickname={myName}
           isEdit={true}

--- a/src/components/MainHeader/MainHeader.tsx
+++ b/src/components/MainHeader/MainHeader.tsx
@@ -28,7 +28,7 @@ const MainHeader = () => {
   ];
 
   return (
-    <header className="flex justify-between items-end h-20 px-800">
+    <header className="flex justify-between items-end h-header px-800">
       <Logo onClick={() => router.push(PATH.HOME)} />
       <div className="flex items-center pl-4">
         <NicknameBar

--- a/src/components/MainHeader/NicknameBar.tsx
+++ b/src/components/MainHeader/NicknameBar.tsx
@@ -18,11 +18,13 @@ const NicknameBar = ({ nickname, isEdit }: NicknameBarProps) => {
   };
 
   return (
-    <section className="nickname-bar bg-container-600 text-subtitle px-500 rounded-full flex justify-center items-center">
+    <section className="nickname-bar bg-container-600 text-subtitle px-500 rounded-full flex justify-center items-center min-w-fit">
       {nickname ? (
         <span className="pointer-events-none px-1">{`닉네임 : ${nickname}`}</span>
       ) : (
-        <Loader className="w-5 h-5 animate-spin text-light" />
+        <div className="py-1">
+          <Loader className="w-5 h-5 animate-spin text-light" />
+        </div>
       )}
       {isEdit && nickname !== '' && (
         <Button

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -30,7 +30,7 @@ const Navigation = ({ items, disabled }: NavigationProps) => {
     }
   });
 
-  return <nav>{Items}</nav>;
+  return <nav className="min-w-fit shrink-0">{Items}</nav>;
 };
 
 export default Navigation;

--- a/src/components/PartialResultChart/PartialResultChart.tsx
+++ b/src/components/PartialResultChart/PartialResultChart.tsx
@@ -29,7 +29,7 @@ const PartialResultChart = ({ data }: PartialResultChartProps) => {
           {partialData.round}라운드 결과
         </h1>
       </section>
-      <section className="flex justify-between items-stretch gap-700">
+      <section className="flex justify-between items-stretch gap-300 grow-0">
         <UserList
           title={partialData.a}
           data={partialData.result.a}

--- a/src/components/PartialResultChart/UserList.tsx
+++ b/src/components/PartialResultChart/UserList.tsx
@@ -12,12 +12,12 @@ const UserList = ({ title, data, className, ...props }: UserListProps) => {
   return (
     <section
       className={cn(
-        'min-w-[13rem] max-w-[54rem] py-500 px-400 rounded-sm flex flex-col gap-300 items-center',
+        'text-sm min-w-[12rem] max-w-[54rem] py-500 px-400 rounded-sm flex flex-col gap-300 items-center',
         className
       )}
       {...props}
     >
-      <h1 className="text-title2">{title}</h1>
+      <h1 className="text-title3">{title}</h1>
       <hr className="w-full border-white/50" />
       <section className="flex flex-col gap-300 items-center">
         {typeof data === 'string'
@@ -25,7 +25,7 @@ const UserList = ({ title, data, className, ...props }: UserListProps) => {
           : data.map((user, index) => (
               <span
                 key={user + index}
-                className="text-body1"
+                className="text-body2"
               >
                 {user}
               </span>

--- a/src/components/PieChart/PieChart.tsx
+++ b/src/components/PieChart/PieChart.tsx
@@ -29,7 +29,7 @@ const PieChart = ({
   className,
   ...props
 }: PieChartProps) => {
-  const defaultClassName = 'w-72';
+  const defaultClassName = 'w-64';
   const combinedClassName = className
     ? cn(defaultClassName, className)
     : defaultClassName;
@@ -63,7 +63,7 @@ const PieChart = ({
         labels: {
           color: '#F0F0F0',
           font: {
-            size: 14,
+            size: 12,
           },
         },
       },
@@ -73,7 +73,7 @@ const PieChart = ({
 
   if (data.length === 0) {
     return (
-      <section className="min-w-72 flex justify-center items-center rounded bg-black/50">
+      <section className="min-w-64 flex justify-center items-center rounded bg-black/50">
         데이터가 없습니다
       </section>
     );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,7 +33,18 @@ const config: Config = {
         '2xl': '1440px',
       },
       fontFamily: {
-        sans: ['var(--font-pretendard)', 'var(--font-noto-sans)', 'sans-serif'],
+        sans: [
+          'var(--font-pretendard)',
+          'var(--font-noto-sans)',
+          'system-ui',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'Segoe UI',
+          'Roboto',
+          'Helvetica Neue',
+          'Arial',
+          'sans-serif',
+        ],
       },
       fontSize: {
         DEFAULT: '1rem',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -94,6 +94,8 @@ const config: Config = {
         'icon-sm': '1rem',
         'icon-md': '1.5rem',
         'icon-lg': '2.25rem',
+        header: '5rem',
+        footer: '5rem',
         'ads-leaderboard': '5.625rem', // 90px
       },
       spacing: {


### PR DESCRIPTION
closes #199, #201 

# 📝작업 내용
맥북 환경에서 영역이 확대되어 스크롤이 발생하는 이슈를 해결했습니다.
작은 화면에서도 사용자 경험을 동일하게 전달하기 위해 반응형 UI를 적용했습니다.
작업 범위는 _메인페이지, 대기실, BalanceGame의 부분/최종 결과 페이지_입니다.

**세부 작업 내용**
- 화면이 작아지면 세로 스크롤이 발생하여 `overflow-y-hidden`을 적용했습니다.
- 미디어쿼리를 도입하여 반응형 UI를 적용했습니다.
- 브라우저에 따라 폰트의 1rem이 달라질 수 있기 때문에 시스템 폰트와 기본 폰트 크기를 명시적으로 선언했습니다.
- 화면 크기가 커지면 폰트 사이즈도 확대되어 가독성을 늘렸습니다.
- 화면 크기가 커지면 GameListCard 크기도 확대됩니다.

**버그 수정**
- 화면이 작아지면 레이아웃이 변형되거나 겹치는 버그를 수정했습니다.
- 컨테이너가 작아지면 텍스트가 줄바꿈되는 버그를 수정했습니다.
- 룸페이지의 고정 너비 광고는 작은 화면에서 채팅 영역을 침범하는 이슈가 있어 '반응형 광고'로 수정했습니다.

# 📷스크린샷
- 테스트 환경 : 윈도우 Chrome 개발자도구 1440x832
## 메인페이지
**AS-IS**
![chrome_Ww0sazXYLt](https://github.com/user-attachments/assets/86c3bf80-3b6e-4a73-b0fe-bb2e0f1b510d)

**TO-BE**
![chrome_AuL6U7BjEA](https://github.com/user-attachments/assets/9a4d5035-1fb9-479a-9a1a-9d99802aba53)

## 대기실페이지
**AS-IS**
![chrome_EfPTqq2I3x](https://github.com/user-attachments/assets/0cb23c01-1022-49b6-954f-4532120f3ea5)
**TO-BE**
![chrome_3FfmaHOupo](https://github.com/user-attachments/assets/71b3e70a-6bcd-4db3-aaaa-3bb795006a71)

## BalancGame 결과
### 부분결과
**AS-IS**
![chrome_V9BAD1nfbt](https://github.com/user-attachments/assets/4528bebd-ca59-4ff1-a8f6-b07da2a501e2)
**TO-BE**
![chrome_vp4tGWozYV](https://github.com/user-attachments/assets/c9e5e1f0-990b-452d-880c-8e10892815a7)

### 최종결과
**AS-IS**
![chrome_COvRRQgoEX](https://github.com/user-attachments/assets/7e52d273-2abf-4b67-8a66-d33fe3727611)
**TO-BE**
![chrome_RRuSlpRIXW](https://github.com/user-attachments/assets/dea4ef40-b86b-4ecb-8a52-eece36d1e45e)

# ✨PR Point
맥북에서 테스트 후 이상한 점 있으면 알려주세요!
