### PR TITLE
소켓 연결 setTimeout 삭제 및 구조 변경

### DIFF
--- a/src/app/room/[roomId]/_component/WaitingRoom.tsx
+++ b/src/app/room/[roomId]/_component/WaitingRoom.tsx
@@ -93,10 +93,7 @@ const WaitingRoom = ({
         router.push(PATH.HOME);
       } else {
         if (!isError && myName !== '') {
-          // @TODO: 조금 더 근본적인 해결책 찾기
-          setTimeout(() => {
-            connect({ roomId, name: myName });
-          });
+          connect({ roomId, name: myName });
         }
       }
     }

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -112,10 +112,7 @@ export function useWebSocket() {
   const sendMessage = <T>(
     params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
   ) => {
-    if (!client.current) {
-      return;
-    }
-    if (!client.current.connected) {
+    if (!client.current || !client.current.connected) {
       return;
     }
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -112,6 +112,13 @@ export function useWebSocket() {
   const sendMessage = <T>(
     params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
   ) => {
+    if (!client.current) {
+      return;
+    }
+    if (!client.current.connected) {
+      return;
+    }
+
     const { destination, body } = params;
     const text = JSON.stringify(body);
 


### PR DESCRIPTION
# 📝작업 내용
#150 에서 작성된 문제점 중 하나였던 방이 생성 되기 전에 connect가 되는 문제를 해결했습니다.

### 문제 상황
- roomDetail이 존재할 때, 즉 방이 생성되었음을 확인한 뒤에 connect를 시도했지만 실패
- 기존에는 아직 서버 상에서는 약간의 딜레이 때문에 실제로는 방이 생성되지 않았을 것이라 추측하고 setTimeout으로 감싸서 임시로 해결
- 에러 메세지: `TypeError: There is no underlying STOMP connection`
- 방 생성의 문제가 아닌 **STOMP 클라이언트가 아직 연결되지 않았는데 sendMessage를 호출**해서 생긴 문제로 보임

```tsx

if (subscribeRoomId && subscribeErrorId) {
    setSubscription([subscribeRoomId, subscribeErrorId]);

    sendMessage({
          destination: `${SOCKET.ROOM.ENTER}`,
          body: {
            roomId,
            name,
          },
    });
 }
```

- 위 코드가 onConnect 내부에 있어서 괜찮아 보이지만, 내부에서 client.current의 생성 및 subscribe()가 **비동기적**으로 처리되기 때문에 소켓 연결이 활성화되기 전까지는 publish() 호출이 실패

### 해결 방법
- sendMessage에서 **client.current.connected가 true일 때** publish() 호출을 할 수 있도록 return문을 추가
- StompJS.Client에 설정한 reconnectDelay 옵션 때문에 내부적으로 재접속은 알아서 시도해줌

# 📷스크린샷(필요 시)

# ✨PR Point
