### PR TITLE
맥북 환경에서 룸 UI 스크롤 이슈

### DIFF
--- a/src/app/room/[roomId]/_component/PrevGame.tsx
+++ b/src/app/room/[roomId]/_component/PrevGame.tsx
@@ -42,6 +42,7 @@ const PrevGame = ({
 }: PrevGameProps) => {
   const gameType = gameToType(roomDetail.game.nameEn);
   const totalRoundsRef = useRef<number>(GAME_QUESTIONS_COUNT[gameType].MIN);
+  const buttonClassName = 'text-sm 2xl:text-base font-semibold w-[11rem]';
 
   const { myName } = useRoomStore();
   const { openModal } = useModalStore();
@@ -112,10 +113,10 @@ const PrevGame = ({
             />
             <Button
               className={cn(
-                'text-base font-semibold w-[12rem]',
+                buttonClassName,
                 !isAllReady && 'pointer-events-none'
               )}
-              size="xl"
+              size="lg"
               variant={
                 isAllReady && roomDetail.players.length !== 1
                   ? 'default'
@@ -145,8 +146,11 @@ const PrevGame = ({
             {isDevelopment && (
               <Button
                 variant={'secondary'}
-                className="text-base font-semibold w-[12rem] flex items-center justify-center gap-2"
-                size="xl"
+                className={cn(
+                  buttonClassName,
+                  'flex items-center justify-center gap-2'
+                )}
+                size="lg"
                 onClick={handleGameChange}
               >
                 <SlidersHorizontal />
@@ -159,8 +163,8 @@ const PrevGame = ({
 
       {!isRoomManager && (
         <Button
-          className="text-base font-semibold w-[12rem]"
-          size="xl"
+          className={buttonClassName}
+          size="lg"
           variant={isReady ? 'waiting' : 'default'}
           onClick={isReady ? handleUnready : handleReady}
         >

--- a/src/app/room/[roomId]/_component/UserList.tsx
+++ b/src/app/room/[roomId]/_component/UserList.tsx
@@ -26,7 +26,7 @@ const UserList = ({ players }: UserListProps) => {
   };
 
   return (
-    <section className="flex flex-col gap-3 h-[80vh] w-[14rem] min-w-[14rem] max-w-[15rem] relative ml-10">
+    <section className="flex flex-col gap-3 h-[80vh] w-[13rem] 2xl:w-[14rem] max-w-[15rem] relative ml-10 shrink-0">
       {roomStatus === ROOM_STATUS.IDLE && (
         <Button
           className="absolute -top-12 left-0"

--- a/src/app/room/[roomId]/_component/UserList.tsx
+++ b/src/app/room/[roomId]/_component/UserList.tsx
@@ -26,10 +26,10 @@ const UserList = ({ players }: UserListProps) => {
   };
 
   return (
-    <section className="flex flex-col gap-3 h-[80vh] w-[13rem] 2xl:w-[14rem] max-w-[15rem] relative ml-10 shrink-0">
+    <section className="flex flex-col gap-3 h-[80vh] w-[13rem] 2xl:w-[14rem] max-w-[15rem] relative pl-10 shrink-0">
       {roomStatus === ROOM_STATUS.IDLE && (
         <Button
-          className="absolute -top-12 left-0"
+          className="absolute -top-12 left-10"
           size={'sm'}
           variant={'secondary'}
           onClick={handleLinkCopy}

--- a/src/app/room/[roomId]/_component/UserList.tsx
+++ b/src/app/room/[roomId]/_component/UserList.tsx
@@ -26,7 +26,7 @@ const UserList = ({ players }: UserListProps) => {
   };
 
   return (
-    <section className="flex flex-col gap-3 h-[80vh] w-[13rem] 2xl:w-[14rem] max-w-[15rem] relative pl-10 shrink-0">
+    <section className="flex flex-col gap-3 h-[80vh] w-[14.5rem] 2xl:w-[16rem] max-w-[16rem] relative pl-10 shrink-0">
       {roomStatus === ROOM_STATUS.IDLE && (
         <Button
           className="absolute -top-12 left-10"

--- a/src/app/room/[roomId]/_component/WaitingRoom.tsx
+++ b/src/app/room/[roomId]/_component/WaitingRoom.tsx
@@ -133,7 +133,7 @@ const WaitingRoom = ({
   }
 
   return (
-    <section className="w-screen min-h-screen flex items-start justify-start 2xl:justify-center gap-4 shrink-0 py-20 overflow-y-hidden">
+    <section className="w-screen min-h-screen flex items-start justify-start 2xl:justify-center gap-4 shrink-0 py-20 overflow-hidden">
       <UserList players={players} />
       <section className="flex flex-col gap-300 h-[calc(100vh-12rem)] min-h-[30rem] max-w-[60%] min-w-max w-full rounded-lg shrink-0">
         <ErrorHandlingWrapper

--- a/src/components/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/UserInfoCard/UserInfoCard.tsx
@@ -59,7 +59,7 @@ const UserInfoCard = ({
         />
         <figcaption className="sr-only">{`${fileName} 캐릭터 이미지`}</figcaption>
       </figure>
-      <div className="w-[calc(100%-4rem)] pl-3 pr-2 flex items-center font-medium justify-between gap-1">
+      <div className="w-[calc(100%-4rem)] flex items-center font-medium justify-between pl-2">
         <span className={cn(myName === name && 'text-primary-400 font-bold')}>
           {name}
         </span>

--- a/src/components/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/UserInfoCard/UserInfoCard.tsx
@@ -35,7 +35,7 @@ const UserInfoCard = ({
       className={cn(
         isReady ? 'bg-primary/50' : 'bg-container',
         isStart && 'bg-container',
-        'w-full h-[4rem] flex rounded-lg relative'
+        'w-full h-[3.5rem] 2xl:h-[4rem] flex rounded-lg relative'
       )}
     >
       {isHost && (
@@ -49,7 +49,7 @@ const UserInfoCard = ({
           />
         </section>
       )}
-      <figure className="flex justify-center items-center rounded-l-lg overflow-hidden w-[4rem] bg-white">
+      <figure className="flex justify-center items-center rounded-l-lg overflow-hidden w-[3rem] 2xl:w-[3.5rem] bg-white">
         <Image
           src={`/images/characters/${fileName}.webp`}
           alt="profile"


### PR DESCRIPTION
# 📝작업 내용
맥북 환경에서 룸 UI 스크롤 이슈를 대응합니다.

**원인과 해결**
- UserList의 margin-left 만큼 가로 영역이 추가되었습니다. 👉padding-left로 대체
- 전체 뷰포트 영역에서 가로/세로 스크롤 크기만큼 추가되었습니다. 👉overflow-hidden으로 스크롤 방어

# 📷스크린샷
<img width="1291" height="869" alt="image" src="https://github.com/user-attachments/assets/74df707e-4431-4dc7-ba79-88754f989060" />

# ✨PR Point
WaitingRoom을 w-[50%]로 조정해도 스크롤은 발생합니다.
`overflow-hidden`로 해결은 되지만, 다른 좋은 방법이 있다면 공유해주세요!

Windows에서 MacbookAir 13인치 기준 테스트를 통과하지만, **실제 맥북 환경에서 테스트 부탁드립니다!**