### PR TITLE
채팅 컴포넌트 자동 스크롤 개선

### DIFF
--- a/src/components/Chatting/Chatting.tsx
+++ b/src/components/Chatting/Chatting.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import * as StompJS from '@stomp/stompjs';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
-import Input from '@/components/Input';
+import { Input } from '@/components';
 import { SOCKET } from '@/constants/websocket';
 import { ChatMessage } from '@/types';
 
@@ -19,7 +19,21 @@ interface ChattingProps {
 
 const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLElement>(null);
+
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  const handleScroll = () => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+
+    const scrollHeight = container.scrollHeight;
+    const scrollTop = container.scrollTop;
+    const clientHeight = container.clientHeight;
+    const isBottom = scrollTop + clientHeight >= scrollHeight - 1;
+
+    setIsAtBottom(isBottom);
+  };
 
   const handleSubmit = (e: React.KeyboardEvent<HTMLInputElement>) => {
     e.preventDefault();
@@ -35,18 +49,37 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
         },
       });
       inputRef.current.value = '';
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
   };
 
   useEffect(() => {
-    //@TODO: 추후에 채팅을 실시간으로 보고 있을 때는 자동 스크롤, 위 채팅을 보고 있을 때는 자동 스크롤이 안되도록 기능 수정
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const lastMessage = chatMessages[chatMessages.length - 1];
+    const isSentByMe = lastMessage.sender === myName;
+    const container = messagesContainerRef.current;
+
+    if (container && (isSentByMe || isAtBottom)) {
+      container.scrollTop = container.scrollHeight + 100;
+    }
+    handleScroll();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chatMessages]);
+
+  useEffect(() => {
+    const container = messagesContainerRef.current;
+    if (container) {
+      container.addEventListener('scroll', handleScroll);
+      return () => {
+        container.removeEventListener('scroll', handleScroll);
+      };
+    }
+  }, []);
 
   return (
     <section className="h-full">
-      <section className="h-[calc(100%-4.5rem)] bg-container-600 rounded-t-lg overflow-auto">
+      <section
+        ref={messagesContainerRef}
+        className="h-[calc(100%-4rem)] bg-container-600 rounded-t-lg overflow-auto"
+      >
         {chatMessages.map((item, index) => (
           <Item
             key={index}
@@ -61,7 +94,6 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
             }
           />
         ))}
-        <div ref={messagesEndRef} />
       </section>
       <section className="h-[4rem] flex justify-center items-center bg-container-600 p-3 rounded-b-lg border-solid border-t-1 border-container-400">
         <Input

--- a/src/components/Chatting/Chatting.tsx
+++ b/src/components/Chatting/Chatting.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as StompJS from '@stomp/stompjs';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Input } from '@/components';
 import { SOCKET } from '@/constants/websocket';
@@ -23,7 +23,7 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
 
   const [isAtBottom, setIsAtBottom] = useState(true);
 
-  const handleScroll = () => {
+  const handleScroll = useCallback(() => {
     const container = messagesContainerRef.current;
     if (!container) return;
 
@@ -33,7 +33,7 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
     const isBottom = scrollTop + clientHeight >= scrollHeight - 1;
 
     setIsAtBottom(isBottom);
-  };
+  }, []);
 
   const handleSubmit = (e: React.KeyboardEvent<HTMLInputElement>) => {
     e.preventDefault();
@@ -63,9 +63,8 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
       container.scrollTop = container.scrollHeight;
     }
     handleScroll();
-
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatMessages, myName]);
+  }, [chatMessages, myName, handleScroll]);
 
   useEffect(() => {
     const container = messagesContainerRef.current;
@@ -75,7 +74,7 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
         container.removeEventListener('scroll', handleScroll);
       };
     }
-  }, []);
+  }, [handleScroll]);
 
   return (
     <section className="h-full">

--- a/src/components/Chatting/Chatting.tsx
+++ b/src/components/Chatting/Chatting.tsx
@@ -53,16 +53,19 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
   };
 
   useEffect(() => {
+    if (chatMessages.length === 0) return;
+
     const lastMessage = chatMessages[chatMessages.length - 1];
     const isSentByMe = lastMessage.sender === myName;
     const container = messagesContainerRef.current;
 
     if (container && (isSentByMe || isAtBottom)) {
-      container.scrollTop = container.scrollHeight + 100;
+      container.scrollTop = container.scrollHeight;
     }
     handleScroll();
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatMessages]);
+  }, [chatMessages, myName]);
 
   useEffect(() => {
     const container = messagesContainerRef.current;


### PR DESCRIPTION
# 📝작업 내용
**개선 사항**
- 이전 채팅을 보고 있을 때는 새로운 채팅이 생겨도 스크롤을 자동으로 내리지 않는다.
    - 그러나 본인이 채팅을 친 경우에는 스크롤을 맨 아래로 내린다.
- 가장 최신 채팅을 보고 있는 경우(스크롤이 맨 아래일 때)에는 새로운 채팅이 생기면 스크롤을 내려 즉시 새로운 채팅을 볼 수 있다.

**오류 해결**
- 이전 채팅을 보고 있을 때 사용자가 채팅을 쳐도 맨 마지막 메세지의 바로 이전 채팅까지만 스크롤이 내려가는 현상 해결
# 📷스크린샷(필요 시)

# ✨PR Point
- 간단한 개선입니다~