### PR TITLE
에러 종류에 따라 에러 바운더리에서 제공하는 기능 세분화

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,9 +50,7 @@ export default function RootLayout({
           href="/icons/apple-icon.png"
         />
       </head>
-      <body
-        className={`font-sans antialiased text-sm 2xl:text-base text relative min-h-screen bg-gradient-purple`}
-      >
+      <body className="font-sans antialiased text-sm 2xl:text-base text relative w-screen h-screen bg-gradient-purple">
         {GA4_ID && process.env.NODE_ENV === 'production' && (
           <>
             <Script

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,7 +50,7 @@ export default function RootLayout({
           href="/icons/apple-icon.png"
         />
       </head>
-      <body className="font-sans antialiased text-sm 2xl:text-base text relative w-screen h-screen bg-gradient-purple">
+      <body className="font-sans antialiased text-sm 2xl:text-base text relative min-h-screen bg-gradient-purple">
         {GA4_ID && process.env.NODE_ENV === 'production' && (
           <>
             <Script

--- a/src/app/room/[roomId]/page.tsx
+++ b/src/app/room/[roomId]/page.tsx
@@ -27,12 +27,14 @@ const RoomPage = () => {
   }, []);
 
   return (
-    <ErrorHandlingWrapper
-      fallbackComponent={ErrorFallback}
-      suspenseFallback={<Spinner />}
-    >
-      <GameRoom {...webSocket} />
-    </ErrorHandlingWrapper>
+    <section className="w-screen h-screen">
+      <ErrorHandlingWrapper
+        fallbackComponent={ErrorFallback}
+        suspenseFallback={<Spinner />}
+      >
+        <GameRoom {...webSocket} />
+      </ErrorHandlingWrapper>
+    </section>
   );
 };
 

--- a/src/components/BalanceGame/BalanceGamePanel/BalanceGameController.tsx
+++ b/src/components/BalanceGame/BalanceGamePanel/BalanceGameController.tsx
@@ -31,12 +31,7 @@ const BalanceGameController = ({
   });
 
   const [isTimeout, setIsTimeout] = useState<boolean>(false);
-  const {
-    data: gameResults,
-    refetch,
-    isError,
-    error,
-  } = useFetchBalanceGameResults({
+  const { data: gameResults, refetch } = useFetchBalanceGameResults({
     roomId,
     round:
       roomStatus === ROOM_STATUS.FINAL_RESULT ? undefined : round.currentRound,
@@ -49,13 +44,6 @@ const BalanceGameController = ({
       setIsTimeout(false);
     }
   }, [isTimeout]);
-
-  // @TODO: 더 선언적으로 error를 처리할 수 있는 방법 찾기
-  useEffect(() => {
-    if (isError) {
-      throw error;
-    }
-  }, [isError]);
 
   const preGameProps = { roomDetail, isRoomManager, sendMessage };
   const progressProps = { sendMessage, setIsTimeout };

--- a/src/components/Common/ErrorBoundary/ErrorFallback.tsx
+++ b/src/components/Common/ErrorBoundary/ErrorFallback.tsx
@@ -18,42 +18,64 @@ const ErrorFallback = ({ error, resetErrorBoundary }: ErrorProps) => {
   const router = useRouter();
   const [count, setCount] = useState(3);
 
+  const isAxiosApiError = isAxiosError(error);
+
+  const errorCode =
+    isAxiosApiError && error.response?.data?.code
+      ? (error.response.data.code as ErrorCode)
+      : null;
+
+  const isRoomDeleteError = errorCode === 'R002';
+
   const message =
-    (isAxiosError(error) &&
-      error.response &&
-      ERROR_MESSAGE[error.response.data.code as ErrorCode]) ||
-    DEFAULT_ERROR_MESSAGE;
+    (errorCode && ERROR_MESSAGE[errorCode]) || DEFAULT_ERROR_MESSAGE;
 
   const gotoHome = useCallback(() => {
     router.push(PATH.HOME);
     resetErrorBoundary();
   }, [resetErrorBoundary, router]);
 
-  useEffect(() => {
-    const intervalId = setInterval(() => {
-      setCount((prev) => prev - 1);
-    }, 1000);
-
-    return () => {
-      clearTimeout(intervalId);
-    };
+  const hardReload = useCallback(() => {
+    window.location.reload();
   }, []);
 
   useEffect(() => {
-    if (count === 0) {
-      gotoHome();
+    if (!isRoomDeleteError) {
+      setCount(3);
+      return;
     }
-  }, [count, gotoHome]);
+
+    // eslint-disable-next-line prefer-const
+    let currentCount = 3;
+    setCount(currentCount);
+
+    const intervalId = setInterval(() => {
+      currentCount -= 1;
+      setCount(currentCount);
+      if (currentCount <= 0) {
+        clearInterval(intervalId);
+        gotoHome();
+      }
+    }, 1000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [isRoomDeleteError, gotoHome]);
 
   return (
     <section className="w-screen h-screen flex flex-col justify-center items-center gap-3">
       <Label>{message}</Label>
-      {message === ERROR_MESSAGE.R002 ? (
+      {isRoomDeleteError ? (
         <p>{`${count}초 후 메인으로 이동해요.`}</p>
       ) : (
         <>
+          {isAxiosApiError ? (
+            <Button onClick={() => resetErrorBoundary()}>다시 불러오기</Button>
+          ) : (
+            <Button onClick={hardReload}>페이지 새로고침</Button>
+          )}
           <Button onClick={gotoHome}>메인으로 이동</Button>
-          <Button onClick={() => resetErrorBoundary()}>다시 불러오기</Button>
         </>
       )}
     </section>

--- a/src/components/Common/ErrorBoundary/ErrorFallback.tsx
+++ b/src/components/Common/ErrorBoundary/ErrorFallback.tsx
@@ -64,7 +64,7 @@ const ErrorFallback = ({ error, resetErrorBoundary }: ErrorProps) => {
   }, [isRoomDeleteError, gotoHome]);
 
   return (
-    <section className="w-screen h-screen flex flex-col justify-center items-center gap-3">
+    <section className="w-full h-full flex flex-col justify-center items-center gap-3">
       <Label>{message}</Label>
       {isRoomDeleteError ? (
         <p>{`${count}초 후 메인으로 이동해요.`}</p>

--- a/src/components/Common/GameRoom/GameRoomController.tsx
+++ b/src/components/Common/GameRoom/GameRoomController.tsx
@@ -35,7 +35,7 @@ const GameRoomController = ({
 
   const { toast } = useToast();
 
-  const { data: roomDetail, error, isError } = useFetchRoomDetail(roomId);
+  const { data: roomDetail, isError } = useFetchRoomDetail(roomId);
 
   const { myName, setHostName, gameId } = useRoomStore();
 
@@ -87,13 +87,6 @@ const GameRoomController = ({
       },
     });
   }, [gameId]);
-
-  // @TODO: 더 선언적으로 error를 처리할 수 있는 방법 찾기
-  useEffect(() => {
-    if (isError) {
-      throw error;
-    }
-  }, [isError]);
 
   // @TODO: 현재 방장이 닉네임 변경 시 제대로 반영이 되지 않아 여기서 무한로딩 발생
   if (!isSelfInPlayers) {

--- a/src/components/Common/GameRoom/GameRoomView.tsx
+++ b/src/components/Common/GameRoom/GameRoomView.tsx
@@ -49,7 +49,6 @@ const GameRoomView = ({
             game={roomDetail.game.nameEn}
             roomId={roomId}
             roomDetail={roomDetail}
-            players={roomDetail.players}
             isRoomManager={isRoomManager}
             sendMessage={sendMessage}
           />

--- a/src/components/Common/GameRoom/GameRoomView.tsx
+++ b/src/components/Common/GameRoom/GameRoomView.tsx
@@ -41,18 +41,20 @@ const GameRoomView = ({
       <UserList players={roomDetail.players} />
 
       <section className="flex flex-col gap-300 h-[calc(100vh-12rem)] min-h-[30rem] max-w-[60%] min-w-max w-full rounded-lg shrink-0">
-        <ErrorHandlingWrapper
-          fallbackComponent={ErrorFallback}
-          suspenseFallback={<Spinner />}
-        >
-          <GamePanel
-            game={roomDetail.game.nameEn}
-            roomId={roomId}
-            roomDetail={roomDetail}
-            isRoomManager={isRoomManager}
-            sendMessage={sendMessage}
-          />
-        </ErrorHandlingWrapper>
+        <section className="bg-container/60 h-full rounded-lg">
+          <ErrorHandlingWrapper
+            fallbackComponent={ErrorFallback}
+            suspenseFallback={<Spinner />}
+          >
+            <GamePanel
+              game={roomDetail.game.nameEn}
+              roomId={roomId}
+              roomDetail={roomDetail}
+              isRoomManager={isRoomManager}
+              sendMessage={sendMessage}
+            />
+          </ErrorHandlingWrapper>
+        </section>
         {isDevelopment && (
           <AdBanner
             type="leaderboard"

--- a/src/components/QnaGame/QnaGameResultsFetcher/QnaGameResultsFetcher.tsx
+++ b/src/components/QnaGame/QnaGameResultsFetcher/QnaGameResultsFetcher.tsx
@@ -25,11 +25,7 @@ const QnaGameResultsFetcher = ({
   const { roomStatus } = useRoomStore();
   const { round } = useQnaGameStore();
 
-  const {
-    data: gameResults,
-    isError,
-    error,
-  } = useFetchQnaGameResults({
+  const { data: gameResults } = useFetchQnaGameResults({
     roomId,
     round:
       roomStatus === ROOM_STATUS.FINAL_RESULT ? undefined : round.currentRound,
@@ -43,13 +39,6 @@ const QnaGameResultsFetcher = ({
       });
     }
   }, [roomStatus, queryClient]);
-
-  // @TODO: 더 선언적으로 error를 처리할 수 있는 방법 찾기
-  useEffect(() => {
-    if (isError) {
-      throw error;
-    }
-  }, [error, isError]);
 
   return (
     <>

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -153,7 +153,6 @@ export function useWebSocket() {
               '방장이 퇴장하여 방이 삭제되었어요. 새로운 방을 이용해주세요.',
             variant: 'destructive',
           });
-          // 방 삭제로 소켓 통신이 불가능하기 때문에 바로 이동
           router.replace(PATH.HOME);
           break;
         }


### PR DESCRIPTION
# 📝작업 내용
### 에러 종류에 따른 기능 세분화
- axios 에러 중 **방 삭제 에러(R002)** 인 경우 3초 후 홈으로 이동
    - 기존 로직은 3초 세는 로직이 무한 반복되는 현상이 발견되어 내부에서 count 계산하는 방식으로 변경
- 그 외의 **axios 에러**는 `다시 불러오기` 버튼 제공
- axios 에러가 아닌 **일반 에러**는 `페이지 새로고침 버튼` 제공

### 에러 바운더리 css 개선
- `body` width, height 각각 `screen`으로 변경
- `ErrorFallback` width, height 각각 `full`로 변경
- GamePanel 감싸는 ErrorBoundary 위에 section css 추가

# ✨PR Point
- #228 머지 후 작업한 내용으로 해당 PR 머지된 이후에 리뷰 부탁드립니다~