### PR TITLE
채팅 컴포넌트 UX 개선 - 새 메시지 알림 및 스크롤 가이드 버튼 구현

### DIFF
--- a/src/components/Chatting/Chatting.tsx
+++ b/src/components/Chatting/Chatting.tsx
@@ -8,6 +8,7 @@ import { SOCKET } from '@/constants/websocket';
 import { ChatMessage } from '@/types';
 
 import Item from './Item';
+import NewMessage from './NewMessage';
 
 interface ChattingProps {
   myName: string;
@@ -52,6 +53,13 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
     }
   };
 
+  const handleNewMessageClick = () => {
+    const container = messagesContainerRef.current;
+    if (container) {
+      container.scrollTop = container.scrollHeight;
+    }
+  };
+
   useEffect(() => {
     if (chatMessages.length === 0) return;
 
@@ -77,25 +85,33 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
   }, [handleScroll]);
 
   return (
-    <section className="h-full">
-      <section
-        ref={messagesContainerRef}
-        className="h-[calc(100%-4rem)] bg-container-600 rounded-t-lg overflow-auto"
-      >
-        {chatMessages.map((item, index) => (
-          <Item
-            key={index}
-            {...item}
-            index={index}
-            type={
-              item.sender === 'system'
-                ? 'system'
-                : item.sender === myName
-                  ? 'me'
-                  : 'others'
-            }
+    <section className="h-full w-full">
+      <section className="h-[calc(100%-4rem)] w-full relative">
+        <section
+          ref={messagesContainerRef}
+          className="h-full w-full box-border bg-container-600 rounded-t-lg overflow-y-auto overflow-w-hidden"
+        >
+          {chatMessages.map((item, index) => (
+            <Item
+              key={index}
+              {...item}
+              index={index}
+              type={
+                item.sender === 'system'
+                  ? 'system'
+                  : item.sender === myName
+                    ? 'me'
+                    : 'others'
+              }
+            />
+          ))}
+        </section>
+        <section className="absolute bottom-0 w-full flex justify-center">
+          <NewMessage
+            message={chatMessages[chatMessages.length - 1].content}
+            onClick={handleNewMessageClick}
           />
-        ))}
+        </section>
       </section>
       <section className="h-[4rem] flex justify-center items-center bg-container-600 p-3 rounded-b-lg border-solid border-t-1 border-container-400">
         <Input

--- a/src/components/Chatting/Chatting.tsx
+++ b/src/components/Chatting/Chatting.tsx
@@ -106,7 +106,7 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
             />
           ))}
         </section>
-        <section className="absolute bottom-0 w-full flex justify-center">
+        <section className="absolute bottom-0 w-full flex justify-center box-border p-2 pr-5">
           <NewMessage
             message={chatMessages[chatMessages.length - 1].content}
             onClick={handleNewMessageClick}

--- a/src/components/Chatting/Chatting.tsx
+++ b/src/components/Chatting/Chatting.tsx
@@ -24,6 +24,8 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
 
   const [isAtBottom, setIsAtBottom] = useState(true);
 
+  const [showNewMessage, setShowNewMessage] = useState(false);
+
   const handleScroll = useCallback(() => {
     const container = messagesContainerRef.current;
     if (!container) return;
@@ -34,6 +36,10 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
     const isBottom = scrollTop + clientHeight >= scrollHeight - 1;
 
     setIsAtBottom(isBottom);
+
+    if (isBottom) {
+      setShowNewMessage(false);
+    }
   }, []);
 
   const handleSubmit = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -66,6 +72,10 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
     const lastMessage = chatMessages[chatMessages.length - 1];
     const isSentByMe = lastMessage.sender === myName;
     const container = messagesContainerRef.current;
+
+    if (!isAtBottom) {
+      setShowNewMessage(true);
+    }
 
     if (container && (isSentByMe || isAtBottom)) {
       container.scrollTop = container.scrollHeight;
@@ -106,12 +116,15 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
             />
           ))}
         </section>
-        <section className="absolute bottom-0 w-full flex justify-center box-border p-2 pr-5">
-          <NewMessage
-            message={chatMessages[chatMessages.length - 1].content}
-            onClick={handleNewMessageClick}
-          />
-        </section>
+        {showNewMessage && (
+          <section className="absolute bottom-0 w-full flex justify-center box-border p-2 pr-5">
+            <NewMessage
+              message={chatMessages[chatMessages.length - 1].content}
+              sender={chatMessages[chatMessages.length - 1].sender}
+              onClick={handleNewMessageClick}
+            />
+          </section>
+        )}
       </section>
       <section className="h-[4rem] flex justify-center items-center bg-container-600 p-3 rounded-b-lg border-solid border-t-1 border-container-400">
         <Input

--- a/src/components/Chatting/Chatting.tsx
+++ b/src/components/Chatting/Chatting.tsx
@@ -73,7 +73,7 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
     const isSentByMe = lastMessage.sender === myName;
     const container = messagesContainerRef.current;
 
-    if (!isAtBottom) {
+    if (!isAtBottom && !isSentByMe) {
       setShowNewMessage(true);
     }
 

--- a/src/components/Chatting/Chatting.tsx
+++ b/src/components/Chatting/Chatting.tsx
@@ -103,7 +103,7 @@ const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {
         >
           {chatMessages.map((item, index) => (
             <Item
-              key={index}
+              key={`${item.sender}-${index}`}
               {...item}
               index={index}
               type={

--- a/src/components/Chatting/Item.tsx
+++ b/src/components/Chatting/Item.tsx
@@ -12,7 +12,7 @@ const Item = ({ sender, content, index, type }: ItemProps) => {
     <div
       className={cn(
         'p-3',
-        index === 0 && 'rounded-t-lg',
+        index === 0 && 'rounded-tl-lg',
         type === 'system'
           ? 'bg-primary/20'
           : index % 2 === 0

--- a/src/components/Chatting/NewMessage.tsx
+++ b/src/components/Chatting/NewMessage.tsx
@@ -8,7 +8,7 @@ interface NewMessageProps {
 const NewMessage = ({ message, onClick }: NewMessageProps) => {
   return (
     <section
-      className="flex items-center w-full h-7 m-2 mr-5 py-1 px-2 gap-1 rounded bg-secondary-700"
+      className="flex items-center box-border w-full h-7 py-1 px-2 gap-1 rounded bg-secondary-700"
       onClick={onClick}
     >
       <ArrowDownToDot size="0.75rem" />

--- a/src/components/Chatting/NewMessage.tsx
+++ b/src/components/Chatting/NewMessage.tsx
@@ -13,7 +13,6 @@ const NewMessage = ({ message, sender, onClick }: NewMessageProps) => {
       onClick={onClick}
       variant={'secondary'}
     >
-      {/* <ArrowDownToDot size="0.75rem" /> */}
       <p className="text-body3 overflow-hidden text-ellipsis whitespace-nowrap">
         {`${sender}: ${message}`}
       </p>

--- a/src/components/Chatting/NewMessage.tsx
+++ b/src/components/Chatting/NewMessage.tsx
@@ -1,0 +1,22 @@
+import { ArrowDownToDot } from 'lucide-react';
+
+interface NewMessageProps {
+  message: string;
+  onClick: () => void;
+}
+
+const NewMessage = ({ message, onClick }: NewMessageProps) => {
+  return (
+    <section
+      className="flex items-center w-full h-7 m-2 mr-5 py-1 px-2 gap-1 rounded bg-secondary-700"
+      onClick={onClick}
+    >
+      <ArrowDownToDot size="0.75rem" />
+      <p className="text-body3 overflow-hidden text-ellipsis whitespace-nowrap">
+        {message}
+      </p>
+    </section>
+  );
+};
+
+export default NewMessage;

--- a/src/components/Chatting/NewMessage.tsx
+++ b/src/components/Chatting/NewMessage.tsx
@@ -9,12 +9,13 @@ interface NewMessageProps {
 const NewMessage = ({ message, sender, onClick }: NewMessageProps) => {
   return (
     <Button
-      className="justify-start w-full h-7 py-1 px-2 gap-1 rounded "
+      className="justify-start w-full h-7 py-1 px-2 gap-1 rounded"
       onClick={onClick}
-      variant={'secondary'}
+      variant="secondary"
     >
       <p className="text-body3 overflow-hidden text-ellipsis whitespace-nowrap">
-        {`${sender}: ${message}`}
+        {sender != 'system' && `${sender}: `}
+        {message}
       </p>
     </Button>
   );

--- a/src/components/Chatting/NewMessage.tsx
+++ b/src/components/Chatting/NewMessage.tsx
@@ -1,21 +1,23 @@
-import { ArrowDownToDot } from 'lucide-react';
+import { Button } from '@/components';
 
 interface NewMessageProps {
   message: string;
+  sender: string;
   onClick: () => void;
 }
 
-const NewMessage = ({ message, onClick }: NewMessageProps) => {
+const NewMessage = ({ message, sender, onClick }: NewMessageProps) => {
   return (
-    <section
-      className="flex items-center box-border w-full h-7 py-1 px-2 gap-1 rounded bg-secondary-700"
+    <Button
+      className="justify-start w-full h-7 py-1 px-2 gap-1 rounded "
       onClick={onClick}
+      variant={'secondary'}
     >
-      <ArrowDownToDot size="0.75rem" />
+      {/* <ArrowDownToDot size="0.75rem" /> */}
       <p className="text-body3 overflow-hidden text-ellipsis whitespace-nowrap">
-        {message}
+        {`${sender}: ${message}`}
       </p>
-    </section>
+    </Button>
   );
 };
 

--- a/src/components/Chatting/NewMessage.tsx
+++ b/src/components/Chatting/NewMessage.tsx
@@ -14,7 +14,7 @@ const NewMessage = ({ message, sender, onClick }: NewMessageProps) => {
       variant="secondary"
     >
       <p className="text-body3 overflow-hidden text-ellipsis whitespace-nowrap">
-        {sender != 'system' && `${sender}: `}
+        {sender !== 'system' && `${sender}: `}
         {message}
       </p>
     </Button>


### PR DESCRIPTION
# 📝작업 내용
- 사용자가 이전 메세지를 스크롤해서 보고 있을 때 새로운 메세지가 오면 채팅 하단에 플로팅 버튼을 띄워줍니다.
- 해당 플로팅 버튼을 누르면 최신 메세지로 이동합니다.
- 최신메세지를 보고 다시 위로 스크롤하면 또 새로운 메세지가 오기 전까지는 플로팅 버튼을 띄우지 않습니다.
- 시스템 메세지는 sender을 표기하지 않습니다.

# 📷스크린샷(필요 시)

https://github.com/user-attachments/assets/e5ae17ff-b17f-43ba-8196-eec6a8990ae0

# ✨PR Point
- #230 머지 후 작업한 내용이므로 해당 PR 머지 후에 리뷰 부탁드립니다~