### PR TITLE
모달 내 소켓 통신을 위한 useSocketStore 생성 및 적용

### DIFF
--- a/src/components/Common/GameListCarousel/GameListCarousel.tsx
+++ b/src/components/Common/GameListCarousel/GameListCarousel.tsx
@@ -13,11 +13,13 @@ import {
   GameListCard,
 } from '@/components';
 import { PATH } from '@/constants/router';
+import { SOCKET } from '@/constants/websocket';
 import { useToast } from '@/hooks/useToast';
 import { cn } from '@/lib/utils';
 import { createRoom } from '@/services/rooms';
 import useModalStore from '@/store/useModalStore';
 import useRoomStore from '@/store/useRoomStore';
+import useSocketStore from '@/store/useSocketStore';
 import { GameResponse } from '@/types/api';
 
 interface GameListCarouselProps {
@@ -29,8 +31,9 @@ const GameListCarousel = ({ games }: GameListCarouselProps) => {
   const router = useRouter();
   const { toast } = useToast();
 
-  const { setRoomId, setGameId } = useRoomStore();
+  const { setRoomId } = useRoomStore();
   const { closeModal } = useModalStore();
+  const { sendMessage } = useSocketStore();
 
   const [isClicked, setIsClicked] = useState(false);
 
@@ -62,7 +65,16 @@ const GameListCarousel = ({ games }: GameListCarouselProps) => {
 
   const handleChangeGame = (gameId: string) => {
     if (isClicked) return;
-    setGameId(gameId);
+
+    if (sendMessage) {
+      sendMessage({
+        destination: `${SOCKET.ROOM.CHANGE_GAME}`,
+        body: {
+          gameId,
+        },
+      });
+    }
+
     closeModal();
     setIsClicked(true);
   };

--- a/src/components/Common/GameRoom/GameRoomController.tsx
+++ b/src/components/Common/GameRoom/GameRoomController.tsx
@@ -7,7 +7,6 @@ import { useEffect } from 'react';
 
 import { Spinner } from '@/components';
 import { PATH } from '@/constants/router';
-import { SOCKET } from '@/constants/websocket';
 import { useFetchRoomDetail } from '@/hooks/queries';
 import { useToast } from '@/hooks/useToast';
 import { EnterRoomProps } from '@/hooks/useWebSocket';
@@ -38,7 +37,7 @@ const GameRoomController = ({
 
   const { data: roomDetail, error, isError } = useFetchRoomDetail(roomId);
 
-  const { myName, setHostName, gameId } = useRoomStore();
+  const { myName, setHostName } = useRoomStore();
   const { setSendMessage } = useSocketStore();
 
   const isRoomManager = roomDetail.players.some(
@@ -76,15 +75,6 @@ const GameRoomController = ({
       }
     }
   }, [myName, roomDetail]);
-
-  useEffect(() => {
-    sendMessage({
-      destination: `${SOCKET.ROOM.CHANGE_GAME}`,
-      body: {
-        gameId,
-      },
-    });
-  }, [gameId]);
 
   // @TODO: 더 선언적으로 error를 처리할 수 있는 방법 찾기
   useEffect(() => {

--- a/src/components/Common/GameRoom/GameRoomController.tsx
+++ b/src/components/Common/GameRoom/GameRoomController.tsx
@@ -12,6 +12,7 @@ import { useFetchRoomDetail } from '@/hooks/queries';
 import { useToast } from '@/hooks/useToast';
 import { EnterRoomProps } from '@/hooks/useWebSocket';
 import useRoomStore from '@/store/useRoomStore';
+import useSocketStore from '@/store/useSocketStore';
 import { ChatMessage } from '@/types';
 
 import GameRoomView from './GameRoomView';
@@ -38,12 +39,19 @@ const GameRoomController = ({
   const { data: roomDetail, error, isError } = useFetchRoomDetail(roomId);
 
   const { myName, setHostName, gameId } = useRoomStore();
+  const { setSendMessage } = useSocketStore();
 
   const isRoomManager = roomDetail.players.some(
     (player) => player.name === myName && player.isHost
   );
   const isSelfInPlayers =
     roomDetail.players.findIndex((user) => user.name === myName) !== -1;
+
+  useEffect(() => {
+    if (sendMessage) {
+      setSendMessage(sendMessage);
+    }
+  }, [sendMessage, setSendMessage]);
 
   useEffect(() => {
     if (roomDetail.players.length > 0) {
@@ -68,15 +76,6 @@ const GameRoomController = ({
       }
     }
   }, [myName, roomDetail]);
-
-  useEffect(() => {
-    sendMessage({
-      destination: `${SOCKET.ROOM.CHANGE_PLAYER_NAME}`,
-      body: {
-        name: myName,
-      },
-    });
-  }, [myName]);
 
   useEffect(() => {
     sendMessage({

--- a/src/components/Common/GameRoom/GameRoomController.tsx
+++ b/src/components/Common/GameRoom/GameRoomController.tsx
@@ -59,7 +59,7 @@ const GameRoomController = ({
         setHostName(host.name);
       }
     }
-  }, [roomDetail.players, setHostName]);
+  }, [roomDetail.players]);
 
   useEffect(() => {
     if (roomDetail && !isSelfInPlayers) {

--- a/src/components/Common/GameRoom/GameRoomController.tsx
+++ b/src/components/Common/GameRoom/GameRoomController.tsx
@@ -35,7 +35,7 @@ const GameRoomController = ({
 
   const { toast } = useToast();
 
-  const { data: roomDetail, error, isError } = useFetchRoomDetail(roomId);
+  const { data: roomDetail, isError } = useFetchRoomDetail(roomId);
 
   const { myName, setHostName } = useRoomStore();
   const { setSendMessage } = useSocketStore();
@@ -75,13 +75,6 @@ const GameRoomController = ({
       }
     }
   }, [myName, roomDetail]);
-
-  // @TODO: 더 선언적으로 error를 처리할 수 있는 방법 찾기
-  useEffect(() => {
-    if (isError) {
-      throw error;
-    }
-  }, [isError]);
 
   if (!isSelfInPlayers) {
     return <Spinner />;

--- a/src/components/Common/GameRoom/GameRoomController.tsx
+++ b/src/components/Common/GameRoom/GameRoomController.tsx
@@ -50,7 +50,7 @@ const GameRoomController = ({
     if (sendMessage) {
       setSendMessage(sendMessage);
     }
-  }, [sendMessage, setSendMessage]);
+  }, [sendMessage]);
 
   useEffect(() => {
     if (roomDetail.players.length > 0) {

--- a/src/components/ModalList/CreateUserNameModal.tsx
+++ b/src/components/ModalList/CreateUserNameModal.tsx
@@ -15,15 +15,18 @@ import {
   ModalShell,
 } from '@/components';
 import { STORAGE_KEY } from '@/constants/storage';
+import { SOCKET } from '@/constants/websocket';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useToast } from '@/hooks/useToast';
 import useModalStore from '@/store/useModalStore';
 import useRoomStore from '@/store/useRoomStore';
+import useSocketStore from '@/store/useSocketStore';
 
 const CreateUserNameModal = () => {
   const { closeModal } = useModalStore();
   const { setItem } = useLocalStorage();
   const { myName, setMyName } = useRoomStore();
+  const { sendMessage } = useSocketStore();
   const { toast } = useToast();
 
   const formSchema = z.object({
@@ -52,14 +55,24 @@ const CreateUserNameModal = () => {
         description: '기존 닉네임과 다른 닉네임을 입력해주세요.',
       });
     } else {
+      setMyName(values.username);
+      setItem(STORAGE_KEY.NICKNAME, values.username);
+      closeModal();
+
+      if (sendMessage) {
+        sendMessage({
+          destination: `${SOCKET.ROOM.CHANGE_PLAYER_NAME}`,
+          body: {
+            name: values.username,
+          },
+        });
+      }
+
       toast({
         variant: 'success',
         title: '닉네임 변경 성공',
         description: `${values.username}님, 그루파이별에 오신 것을 환영해요!`,
       });
-      setMyName(values.username);
-      setItem(STORAGE_KEY.NICKNAME, values.username);
-      closeModal();
     }
   };
 

--- a/src/components/ModalList/CreateUserNameModal.tsx
+++ b/src/components/ModalList/CreateUserNameModal.tsx
@@ -57,7 +57,6 @@ const CreateUserNameModal = () => {
     } else {
       setMyName(values.username);
       setItem(STORAGE_KEY.NICKNAME, values.username);
-      closeModal();
 
       if (sendMessage) {
         sendMessage({
@@ -73,6 +72,8 @@ const CreateUserNameModal = () => {
         title: '닉네임 변경 성공',
         description: `${values.username}님, 그루파이별에 오신 것을 환영해요!`,
       });
+
+      closeModal();
     }
   };
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -4,7 +4,7 @@
 import * as StompJS from '@stomp/stompjs';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { DEFAULT_ERROR_MESSAGE, ERROR_MESSAGE } from '@/constants/error';
 import { QUERYKEY } from '@/constants/querykey';
@@ -109,22 +109,23 @@ export function useWebSocket() {
     client.current = null;
   };
 
-  const sendMessage = <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => {
-    if (!client.current || !client.current.connected) {
-      return;
-    }
+  const sendMessage = useCallback(
+    <T>(params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }) => {
+      if (!client.current || !client.current.connected) {
+        return;
+      }
 
-    const { destination, body } = params;
-    const text = JSON.stringify(body);
+      const { destination, body } = params;
+      const text = JSON.stringify(body);
 
-    client.current?.publish({
-      ...params,
-      destination: `${SOCKET.PUBLICATION}${destination}`,
-      body: text,
-    });
-  };
+      client.current?.publish({
+        ...params,
+        destination: `${SOCKET.PUBLICATION}${destination}`,
+        body: text,
+      });
+    },
+    []
+  );
 
   const receiveMessage = (message: string) => {
     const { type, sender, content } = JSON.parse(message);

--- a/src/store/useBalanceGameStore.ts
+++ b/src/store/useBalanceGameStore.ts
@@ -6,7 +6,6 @@ interface BalanceGameStoreProps {
   round: BalanceGameRoundResponse;
   selectedPlayers: string[];
   setRound: (round: BalanceGameRoundResponse) => void;
-  setTotalRounds: (count: number) => void; // @TODO: 추후에 완전 삭제 필요
   addSelectedPlayers: (player: string) => void;
   resetSelectedPlayers: () => void;
 }
@@ -20,20 +19,11 @@ const useBalanceGameStore = create<BalanceGameStoreProps>((set) => ({
     currentRound: 0,
     playSeconds: 0,
   },
-
   selectedPlayers: [],
   setRound: (round: BalanceGameRoundResponse) =>
     set({
       round,
     }),
-
-  setTotalRounds: (count) =>
-    set((state) => ({
-      round: {
-        ...state.round,
-        totalRounds: count,
-      },
-    })),
   addSelectedPlayers: (player) =>
     set((state) => ({
       selectedPlayers: [...state.selectedPlayers, player],

--- a/src/store/useQnaGameStore.ts
+++ b/src/store/useQnaGameStore.ts
@@ -6,7 +6,6 @@ interface BalanceGameStoreProps {
   round: QnaGameRoundResponse;
   submittedPlayers: string[];
   setRound: (round: QnaGameRoundResponse) => void;
-  setTotalRounds: (count: number) => void; // @TODO: 추후에 완전 삭제 필요
   addSubmittedPlayer: (playerId: string) => void;
   clearSubmittedPlayers: () => void;
   reset: () => void;
@@ -23,13 +22,6 @@ const useQnaGameStore = create<BalanceGameStoreProps>((set) => ({
     set({
       round,
     }),
-  setTotalRounds: (count) =>
-    set((state) => ({
-      round: {
-        ...state.round,
-        totalRounds: count,
-      },
-    })),
   addSubmittedPlayer: (playerId) =>
     set((state) => ({
       submittedPlayers: [...state.submittedPlayers, playerId],

--- a/src/store/useRoomStore.ts
+++ b/src/store/useRoomStore.ts
@@ -11,7 +11,6 @@ interface RoomStoreProps {
   myName: string;
   setRoomStatus: (status: roomStatusType) => void;
   setRoomId: (id: string) => void;
-  setGameId: (id: string) => void;
   setHostName: (name: string) => void;
   setMyName: (name: string) => void;
   getHostName: () => string | null;
@@ -26,7 +25,6 @@ const useRoomStore = create<RoomStoreProps>((set, get) => ({
   myName: '',
   setRoomStatus: (status) => set({ roomStatus: status }),
   setRoomId: (id) => set({ roomId: id }),
-  setGameId: (id) => set({ gameId: id }),
   setHostName: (name) => set({ hostName: name }),
   setMyName: (name) => set({ myName: name }),
   getHostName: () => get().hostName,

--- a/src/store/useSocketStore.ts
+++ b/src/store/useSocketStore.ts
@@ -6,9 +6,11 @@ interface SocketStoreProps {
     | (<T>(params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }) => void)
     | null;
   setSendMessage: (
-    sendFn: <T>(
-      params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-    ) => void
+    sendFn:
+      | (<T>(
+          params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
+        ) => void)
+      | null
   ) => void;
 }
 

--- a/src/store/useSocketStore.ts
+++ b/src/store/useSocketStore.ts
@@ -1,0 +1,20 @@
+import * as StompJS from '@stomp/stompjs';
+import { create } from 'zustand';
+
+interface SocketStoreProps {
+  sendMessage:
+    | (<T>(params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }) => void)
+    | null;
+  setSendMessage: (
+    sendFn: <T>(
+      params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
+    ) => void
+  ) => void;
+}
+
+const useSocketStore = create<SocketStoreProps>((set) => ({
+  sendMessage: null,
+  setSendMessage: (sendFn) => set({ sendMessage: sendFn }),
+}));
+
+export default useSocketStore;


### PR DESCRIPTION
# 📝작업 내용
### 기존 구조의 문제점
```tsx
// GameRoomController.tsx

useEffect(() => {
    sendMessage({
      destination: `${SOCKET.ROOM.CHANGE_PLAYER_NAME}`,
      body: {
        name: myName,
      },
    });
  }, [myName]);

  useEffect(() => {
    sendMessage({
      destination: `${SOCKET.ROOM.CHANGE_GAME}`,
      body: {
        gameId,
      },
    });
  }, [gameId]);
```

- 현재 모달에 직접 전달해줄 수 있는 `optionNumberprops`의 타입은 `string | number`이기 때문에, 모달 내부에서 직접 sendMessage를 사용할 수 없었습니다.
- 따라서 `GameRoom`에서 useEffect의 의존성 배열에 `myName`, `gamdId`를 넣어 간접적으로 변경을 감지하여 sendMessage를 통해 소켓 통신을 하도록 설계했습니다.
- 그러나 해당 코드는 **처음 GameRoom이 렌더링 될 때(방에 처음 입장했을 때)도 발동**되기 때문에, 종종 의도하지 않은 소켓 통신이 일어났습니다.

<img width="1030" height="286" alt="image" src="https://github.com/user-attachments/assets/c1c8b8fb-5a85-4842-803d-b3e9e800c55e" />
<img width="1286" height="412" alt="image" src="https://github.com/user-attachments/assets/07759e2a-6653-4e82-92b3-4bd72bfba65f" />

#### 현재 발견된 에러 상황 
- 카드 게임을 제외한 다른 게임에서 `게임 변경하기`를 통해 카드 게임으로 변경
- 현재 상황은 **소켓에 연결된 상태에서 게임만 변경**하고 있으므로 `sendMessage`가 유효함
- 여기서 카드 게임이 **서버에는 존재하지만 아직 클라이언트 개발이 진행되지 않아** `GamePanel`에서 에러 발생
- 그러나 `GameRoom`컴포넌트는 상위 컴포넌트이므로 렌더링에 문제x, 정상적으로 렌더링됨
- `GameRoom` 렌더링 중 useEffect문의 `sendMessage`가 발동하여 `게임 변경`, `닉네임 변경` 로직 각각 2번씩 수행(react의 strictMode때문)
- GamePanel의 에러로 홈으로 이동
- 이때 원래는 토스트 메세지에 **카드 플립 게임이 없다**고 떠야하지만, 닉네임 변경 로직이 수행되었기 때문에 **사용자에게 엉뚱한 경고 메세지**가 뜸


### 개선된 구조
- `useSocketStore` 생성, 소켓 연결 시 `sendMessage` 함수 저장
- 게임 변경 모달(`GameListCarousel`), 닉네임 변경 모달(`CreateUserNameModal`)에서 직접 store에 저장된 `sendMessage`를 통해 핸들러 함수에서 소켓 통신하도록 변경
- 기존 `useEffect`문 삭제
- 사용되지 않는 store의 set함수 삭제

<img width="898" height="406" alt="image" src="https://github.com/user-attachments/assets/4e0c60f2-5757-4b9c-b5f3-1e50279d6297" />

- 사용자에게 올바른 에러 토스트 메세지가 뜹니다.

# ✨PR Point
- #228 머지 후 작업한 내용이므로 해당 PR 머지되면 리뷰 부탁드립니다~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized WebSocket sender for real-time room actions to improve synchronization and reduce duplicate/stale notifications.
  * Memoized message sender for more stable behavior across renders.

* **Bug Fixes**
  * Nickname updates now close the dialog before showing success feedback and reliably notify other players.
  * Game-change notifications are sent via the centralized sender to keep all clients in sync.

* **Chore**
  * Total rounds can no longer be updated dynamically and remain as initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->