### PR TITLE
SendMessage 공통 타입으로 분리

### DIFF
--- a/src/components/Common/Chatting/Chatting.tsx
+++ b/src/components/Common/Chatting/Chatting.tsx
@@ -1,20 +1,18 @@
 'use client';
 
-import * as StompJS from '@stomp/stompjs';
 import React, { useEffect, useRef } from 'react';
 
 import { Input } from '@/components';
 import { SOCKET } from '@/constants/websocket';
 import { ChatMessage } from '@/types';
+import { SendMessage } from '@/types/websocket';
 
 import Item from './Item';
 
 interface ChattingProps {
   myName: string;
   chatMessages: ChatMessage[];
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void;
+  sendMessage: SendMessage;
 }
 
 const Chatting = ({ myName, chatMessages, sendMessage }: ChattingProps) => {

--- a/src/components/Common/GameActionButtons/GameActionButtonsController.tsx
+++ b/src/components/Common/GameActionButtons/GameActionButtonsController.tsx
@@ -1,17 +1,14 @@
 'use client';
 
-import * as StompJS from '@stomp/stompjs';
-
 import { GameControlEntry } from '@/constants/gameControlMap';
 import useRoomStore from '@/store/useRoomStore';
+import { SendMessage } from '@/types/websocket';
 
 import GameActionButtonsView from './GameActionButtonsView';
 
 interface GameActionButtonsControllerProps {
   gameControl: GameControlEntry;
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void;
+  sendMessage: SendMessage;
 }
 
 const GameActionButtonsController = ({

--- a/src/components/Common/GameRoom/GameRoomController.tsx
+++ b/src/components/Common/GameRoom/GameRoomController.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 
-import * as StompJS from '@stomp/stompjs';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
@@ -15,15 +14,14 @@ import { EnterRoomProps } from '@/hooks/useWebSocket';
 import useRoomStore from '@/store/useRoomStore';
 import useSocketStore from '@/store/useSocketStore';
 import { ChatMessage } from '@/types';
+import { SendMessage } from '@/types/websocket';
 import { gameToType } from '@/utils/gameToType';
 
 import GameRoomView from './GameRoomView';
 
 interface GameRoomControllerProps {
   connect: (params: EnterRoomProps) => void;
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void;
+  sendMessage: SendMessage;
   chatMessages: ChatMessage[];
 }
 

--- a/src/components/Common/GameRoom/GameRoomView.tsx
+++ b/src/components/Common/GameRoom/GameRoomView.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 
-import * as StompJS from '@stomp/stompjs';
 import { ComponentType } from 'react';
 
 import {
@@ -18,6 +17,7 @@ import { ChatMessage } from '@/types';
 import { RoomResponse } from '@/types/api';
 import { GameType } from '@/types/game';
 import { GameControllerProps } from '@/types/props';
+import { SendMessage } from '@/types/websocket';
 import { isDevelopment } from '@/utils/env';
 
 interface GameRoomViewProps {
@@ -25,9 +25,7 @@ interface GameRoomViewProps {
   roomId: string;
   myName: string;
   isRoomManager: boolean;
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void;
+  sendMessage: SendMessage;
   chatMessages: ChatMessage[];
   GamePanel: ComponentType<GameControllerProps>;
   gameControl: GameControlEntry;

--- a/src/components/QnaGame/QnaGamePartialResult/QnaGamePartialResult.tsx
+++ b/src/components/QnaGame/QnaGamePartialResult/QnaGamePartialResult.tsx
@@ -1,18 +1,15 @@
 'use client';
 
-import * as StompJS from '@stomp/stompjs';
-
 import { SOCKET } from '@/constants/websocket';
 import useQnaGameStore from '@/store/useQnaGameStore';
 import { QnaGameResultGetResponse } from '@/types/api';
+import { SendMessage } from '@/types/websocket';
 
 import UserAnswerRow from './UserAnswerRow';
 
 interface QnaGamePartialResultProps {
   data: QnaGameResultGetResponse[];
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void;
+  sendMessage: SendMessage;
 }
 
 const QnaGamePartialResult = ({

--- a/src/components/QnaGame/QnaGameProgress/QnaGameProgress.tsx
+++ b/src/components/QnaGame/QnaGameProgress/QnaGameProgress.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 
-import * as StompJS from '@stomp/stompjs';
 import { useQueryClient } from '@tanstack/react-query';
 import React, { useEffect } from 'react';
 
@@ -12,11 +11,10 @@ import { SOCKET } from '@/constants/websocket';
 import useQnaGameStore from '@/store/useQnaGameStore';
 import useRoomStore from '@/store/useRoomStore';
 import { Player } from '@/types/api';
+import { SendMessage } from '@/types/websocket';
 
 interface QnaGameProgressProps {
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void;
+  sendMessage: SendMessage;
   players: Player[];
 }
 

--- a/src/components/QnaGame/QnaGameResultsFetcher/QnaGameResultsFetcher.tsx
+++ b/src/components/QnaGame/QnaGameResultsFetcher/QnaGameResultsFetcher.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as StompJS from '@stomp/stompjs';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
@@ -10,12 +9,11 @@ import { ROOM_STATUS } from '@/constants/room';
 import { useFetchQnaGameResults } from '@/hooks/queries';
 import useQnaGameStore from '@/store/useQnaGameStore';
 import useRoomStore from '@/store/useRoomStore';
+import { SendMessage } from '@/types/websocket';
 
 interface QnaGameResultsFetcherProps {
   roomId: string;
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void;
+  sendMessage: SendMessage;
 }
 
 const QnaGameResultsFetcher = ({

--- a/src/hooks/useAutoEndGame.ts
+++ b/src/hooks/useAutoEndGame.ts
@@ -1,10 +1,10 @@
-import * as StompJS from '@stomp/stompjs';
 import { useEffect } from 'react';
 
 import { ToastProps } from '@/components';
 import { GAME_CONTROL_MAP } from '@/constants/gameControlMap';
 import { RoomResponse } from '@/types/api';
 import { GameType } from '@/types/game';
+import { SendMessage } from '@/types/websocket';
 
 import { ToasterToast } from './useToast';
 
@@ -16,9 +16,7 @@ type ToastFunction = (props: ToastProps) => {
 
 interface AutoEndGameProps {
   roomDetail: RoomResponse;
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void;
+  sendMessage: SendMessage;
   toast: ToastFunction;
   gameType: GameType;
 }

--- a/src/hooks/useThrottleHandlers.ts
+++ b/src/hooks/useThrottleHandlers.ts
@@ -1,14 +1,10 @@
-import * as StompJS from '@stomp/stompjs';
 import { useMemo } from 'react';
 
 import { SOCKET } from '@/constants/websocket';
+import { SendMessage } from '@/types/websocket';
 import { throttle } from '@/utils/throttle';
 
-const useThrottleReadyHandlers = (
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void
-) => {
+const useThrottleReadyHandlers = (sendMessage: SendMessage) => {
   const handleReady = useMemo(() => {
     const throttledFn = throttle(() => {
       sendMessage({

--- a/src/store/useSocketStore.ts
+++ b/src/store/useSocketStore.ts
@@ -1,17 +1,10 @@
-import * as StompJS from '@stomp/stompjs';
 import { create } from 'zustand';
 
+import { SendMessage } from '@/types/websocket';
+
 interface SocketStoreProps {
-  sendMessage:
-    | (<T>(params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }) => void)
-    | null;
-  setSendMessage: (
-    sendFn:
-      | (<T>(
-          params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-        ) => void)
-      | null
-  ) => void;
+  sendMessage: SendMessage | null;
+  setSendMessage: (sendFn: SendMessage | null) => void;
 }
 
 const useSocketStore = create<SocketStoreProps>((set) => ({

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,24 +1,19 @@
-import * as StompJS from '@stomp/stompjs';
-
 import { RoomResponse } from '@/types/api';
 
 import { GameType } from './game';
+import { SendMessage } from './websocket';
 
 export interface GameControllerProps {
   roomId: string;
   roomDetail: RoomResponse;
   isRoomManager: boolean;
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void;
+  sendMessage: SendMessage;
   gameType: GameType;
 }
 
 export type PreGameControllerProps = Omit<GameControllerProps, 'roomId'>;
 
 export interface BalanceGameProgressProps {
-  sendMessage: <T>(
-    params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
-  ) => void;
+  sendMessage: SendMessage;
   setIsTimeout: (state: boolean) => void;
 }

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -1,3 +1,9 @@
+import * as StompJS from '@stomp/stompjs';
+
+export type SendMessage = <T>(
+  params: Omit<StompJS.IPublishParams, 'body'> & { body?: T }
+) => void;
+
 /* Response */
 
 export interface BalanceGameRoundResponse {

--- a/src/utils/gameStartHandlers.ts
+++ b/src/utils/gameStartHandlers.ts
@@ -1,9 +1,10 @@
 import { GAME_TYPES } from '@/constants/game';
 import { SOCKET } from '@/constants/websocket';
 import { RoomResponse } from '@/types/api';
+import { SendMessage } from '@/types/websocket';
 
 export interface StartHandlerParams {
-  sendMessage: <T>(params: { destination: string; body?: T }) => void;
+  sendMessage: SendMessage;
   roomDetail: RoomResponse;
   totalRounds: number;
 }


### PR DESCRIPTION
# 📝작업 내용
sendMessage는 프로젝트 전반적으로 자주 사용하게 되는 메소드지만, sendMessage의 타입이 복잡하기에 매번 타입을 찾아 복사하는 과정이 다소 번거롭게 느껴졌습니다.
따라서 `SendMessage` 라는 이름의 공통 타입으로 분리하여 편하게 타입을 작성할 수 있도록 개선했습니다.

# ✨PR Point
- #240 #238 먼저 머지 후 작업한 내용입니다! 해당 PR 머지되면 리뷰해주시면 좋을 것 같습니다~